### PR TITLE
refactor: Embed net.TcpConn in custom connection struct to avoid manual method implementations

### DIFF
--- a/net/conn.go
+++ b/net/conn.go
@@ -14,50 +14,7 @@ import (
 const BUF_SIZE = 1024
 
 type Conn struct {
-	conn *net.TCPConn
-}
-
-func (c *Conn) CloseWrite() {
-	c.conn.CloseWrite()
-}
-
-func (c *Conn) CloseRead() {
-	c.conn.CloseRead()
-}
-
-func (c *Conn) Close() {
-	c.conn.Close()
-}
-
-func (c *Conn) RemoteAddr() net.Addr {
-	return c.conn.RemoteAddr()
-}
-
-func (c *Conn) LocalAddr() net.Addr {
-	return c.conn.LocalAddr()
-}
-
-func (c *Conn) Read(b []byte) (n int, err error) {
-	return c.conn.Read(b)
-}
-
-func (c *Conn) Write(b []byte) (n int, err error) {
-	return c.conn.Write(b)
-}
-
-func (c *Conn) SetReadDeadline(t time.Time) error {
-	c.conn.SetReadDeadline(t)
-	return nil
-}
-
-func (c *Conn) SetDeadLine(t time.Time) error {
-	c.conn.SetDeadline(t)
-	return nil
-}
-
-func (c *Conn) SetKeepAlive(b bool) error {
-	c.conn.SetKeepAlive(b)
-	return nil
+	net.TCPConn
 }
 
 func (conn *Conn) WriteChunks(c [][]byte) (n int, err error) {
@@ -219,7 +176,7 @@ func (from *Conn) Serve(to *Conn, proto string, fd string, td string) {
 	proto += " "
 
 	for {
-		from.conn.SetReadDeadline(time.Now().Add(2000 * time.Millisecond))
+		from.SetReadDeadline(time.Now().Add(2000 * time.Millisecond))
 		buf, err := from.ReadBytes()
 		if err != nil {
 			if err == io.EOF {

--- a/net/dial.go
+++ b/net/dial.go
@@ -27,5 +27,5 @@ func DialTCP(network string, ip string, port string) (*Conn, error) {
 		return &Conn{}, err
 	}
 
-	return &Conn{conn: conn}, nil
+	return &Conn{*conn}, nil
 }

--- a/net/listener.go
+++ b/net/listener.go
@@ -14,5 +14,5 @@ func (l *Listener) Accept() (*Conn, error) {
 		return &Conn{}, err
 	}
 
-	return &Conn{conn: conn}, nil
+	return &Conn{*conn}, nil
 }


### PR DESCRIPTION
### Changes:
- The custom `Conn` structure now embeds the standard library `net.TcpConn`.
- Functions already available via embedding are removed.
- `Conn` structures now require dereferencing the TCP connection accepted when listening.