### PR TITLE
Fix accumulator when reading bytes

### DIFF
--- a/net/conn.go
+++ b/net/conn.go
@@ -25,7 +25,7 @@ func (conn *Conn) WriteChunks(c [][]byte) (n int, err error) {
 			return 0, nil
 		}
 
-		b += total
+		total += b
 	}
 
 	return total, nil


### PR DESCRIPTION
This does not affect the current implementation since the total bytes written is ignored. However, when the number of bytes written is actually compared, say for parity check, it returns an incorrect value.