### PR TITLE
set default timeout to 2000ms

### DIFF
--- a/net/conn.go
+++ b/net/conn.go
@@ -176,11 +176,9 @@ func (from *Conn) Serve(to *Conn, proto string, fd string, td string, timeout in
 	proto += " "
 
 	for {
-		if timeout > 0 {
-			from.SetReadDeadline(
-				time.Now().Add(time.Millisecond * time.Duration(timeout)),
-			)
-		}
+    from.SetReadDeadline(
+      time.Now().Add(time.Millisecond * time.Duration(timeout)),
+    )
 
 		buf, err := from.ReadBytes()
 		if err != nil {

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -39,11 +39,9 @@ func (p *Proxy) Start() {
 		os.Exit(1)
 	}
 
-	if p.timeout > 0 {
-        log.Println(fmt.Sprintf("Connection timeout is set to %dms", p.timeout))
-    }
+  log.Println(fmt.Sprintf("Connection timeout is set to %dms", p.timeout))
 
-    log.Println("Created a listener on port", p.Port())
+	log.Println("Created a listener on port", p.Port())
 
 	for {
 		conn, err := l.Accept()

--- a/util/config.go
+++ b/util/config.go
@@ -56,7 +56,7 @@ func ParseArgs() {
 	config.Dns = flag.String("dns", "8.8.8.8", "DNS server")
 	config.Debug = flag.Bool("debug", false, "true | false")
 	config.NoBanner = flag.Bool("no-banner", false, "true | false")
-	config.Timeout = flag.Int("timeout", 0, "timeout in milliseconds")
+	config.Timeout = flag.Int("timeout", 2000, "timeout in milliseconds")
 
 	flag.Var(&allowedHosts, "url", "Bypass DPI only on this url, can be passed multiple times")
 	allowedPattern = flag.String(


### PR DESCRIPTION
there are some cases that the connection gets closed too early when requesting to website which is located geograchically far from the client, so that we set the default connection timeout to 2000ms for better user experience.