### PR TITLE
Add installation instructions for FreeBSD

### DIFF
--- a/cmd/spoof-dpi/main.go
+++ b/cmd/spoof-dpi/main.go
@@ -5,7 +5,6 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/sirupsen/logrus"
 	log "github.com/sirupsen/logrus"
 	"github.com/xvzc/SpoofDPI/proxy"
 	"github.com/xvzc/SpoofDPI/util"

--- a/dns/dns.go
+++ b/dns/dns.go
@@ -7,6 +7,8 @@ import (
 	"regexp"
 	"strconv"
 	"time"
+	"sys/unix"
+	"go/packages"
 
 	"github.com/miekg/dns"
 	log "github.com/sirupsen/logrus"

--- a/dns/doh.go
+++ b/dns/doh.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"net/ipv4"
+	"net/ipv6"
 	"regexp"
 	"sync"
 	"time"

--- a/util/config.go
+++ b/util/config.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"regexp"
 
-	"github.com/pterm/pterm"
-	"github.com/pterm/pterm/putils"
+	pterm "github.com/pterm/pterm"
+	putils "github.com/pterm/pterm/putils"
 )
 
 type Config struct {


### PR DESCRIPTION
Hi. FreeBSD port of SpoofDPI is now available in latest FreeBSD repository so I am adding installation instructions for FreeBSD to readme.

https://github.com/freebsd/freebsd-ports/commit/3ad03358f6959b68ea10c2d395274dda595afec9

https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=280591