### PR TITLE
feat: move doh to internal

### DIFF
--- a/dns/dns.go
+++ b/dns/dns.go
@@ -93,16 +93,13 @@ func dohLookup(domain string) (string, error) {
 
 	dnsUpstream := util.GetConfig().DnsAddr
 	client := GetDoHClient(*dnsUpstream)
-	// try up to 3 times
-	for i := 0; i < 3; i++ {
-		resp, err := client.Resolve(ctx, domain, []uint16{dns.TypeA, dns.TypeAAAA})
-		if err == nil {
-			if len(resp) == 0 { // yes this happens
-				return "", errors.New("no record found(doh)")
-			}
-
-			return resp[0], nil
+	resp, err := client.Resolve(ctx, domain, []uint16{dns.TypeA, dns.TypeAAAA})
+	if err == nil {
+		if len(resp) == 0 { // yes this happens
+			return "", errors.New("no record found(doh)")
 		}
+
+		return resp[0], nil
 	}
 
 	return "", errors.New("could not resolve the domain(doh)")

--- a/dns/doh.go
+++ b/dns/doh.go
@@ -1,0 +1,107 @@
+package dns
+
+import (
+	"bytes"
+	"encoding/base64"
+	"fmt"
+	"net"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/miekg/dns"
+	log "github.com/sirupsen/logrus"
+)
+
+type DoHClient struct {
+	upstream string
+	c        *http.Client
+}
+
+var client *DoHClient
+
+func GetDoHClient(upstream string) *DoHClient {
+	if client == nil {
+		if !strings.HasPrefix(upstream, "https://") {
+			upstream = "https://" + upstream
+		}
+
+		if !strings.HasSuffix(upstream, "/dns-query") {
+			upstream = upstream + "/dns-query"
+		}
+
+		c := &http.Client{
+			Timeout: 5 * time.Second,
+			Transport: &http.Transport{
+				DialContext: (&net.Dialer{
+					Timeout:   3 * time.Second,
+					KeepAlive: 30 * time.Second,
+				}).DialContext,
+				TLSHandshakeTimeout: 5 * time.Second,
+				MaxIdleConnsPerHost: 100,
+				MaxIdleConns:        100,
+			},
+		}
+
+		client = &DoHClient{
+			upstream: upstream,
+			c:        c,
+		}
+	}
+
+	return client
+}
+
+func (d *DoHClient) doGetRequest(msg *dns.Msg) (*dns.Msg, error) {
+	pack, err := msg.Pack()
+	if err != nil {
+		return nil, err
+	}
+
+	url := fmt.Sprintf("%s?dns=%s", d.upstream, base64.RawStdEncoding.EncodeToString(pack))
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Accept", "application/dns-message")
+
+	resp, err := d.c.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		log.Debug("[DoH] Error while resolving ", url, " : ", resp.Status)
+	}
+
+	buf := bytes.Buffer{}
+	buf.ReadFrom(resp.Body)
+
+	ret_msg := new(dns.Msg)
+	err = ret_msg.Unpack(buf.Bytes())
+	if err != nil {
+		return nil, err
+	}
+
+	return ret_msg, nil
+}
+
+func (d *DoHClient) Resolve(domain string, dnsType uint16) ([]string, error) {
+	msg := new(dns.Msg)
+	msg.SetQuestion(dns.Fqdn(domain), dnsType)
+
+	resp, err := d.doGetRequest(msg)
+	if err != nil {
+		return nil, err
+	}
+
+	var ret []string
+	for _, ans := range resp.Answer {
+		if a, ok := ans.(*dns.A); ok {
+			ret = append(ret, a.A.String())
+		}
+	}
+	return ret, nil
+}

--- a/dns/doh.go
+++ b/dns/doh.go
@@ -2,6 +2,7 @@ package dns
 
 import (
 	"bytes"
+	"context"
 	"encoding/base64"
 	"fmt"
 	"net"
@@ -52,7 +53,7 @@ func GetDoHClient(upstream string) *DoHClient {
 	return client
 }
 
-func (d *DoHClient) doGetRequest(msg *dns.Msg) (*dns.Msg, error) {
+func (d *DoHClient) doGetRequest(ctx context.Context, msg *dns.Msg) (*dns.Msg, error) {
 	pack, err := msg.Pack()
 	if err != nil {
 		return nil, err
@@ -64,6 +65,7 @@ func (d *DoHClient) doGetRequest(msg *dns.Msg) (*dns.Msg, error) {
 		return nil, err
 	}
 
+	req = req.WithContext(ctx)
 	req.Header.Set("Accept", "application/dns-message")
 
 	resp, err := d.c.Do(req)
@@ -88,14 +90,14 @@ func (d *DoHClient) doGetRequest(msg *dns.Msg) (*dns.Msg, error) {
 	return ret_msg, nil
 }
 
-func (d *DoHClient) Resolve(domain string, dnsTypes []uint16) ([]string, error) {
+func (d *DoHClient) Resolve(ctx context.Context, domain string, dnsTypes []uint16) ([]string, error) {
 	var ret []string
 
 	for _, dnsType := range dnsTypes {
 		msg := new(dns.Msg)
 		msg.SetQuestion(dns.Fqdn(domain), dnsType)
 
-		resp, err := d.doGetRequest(msg)
+		resp, err := d.doGetRequest(ctx, msg)
 		if err != nil {
 			return nil, err
 		}

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.21
 toolchain go1.21.5
 
 require (
-	github.com/likexian/doh v0.7.1
 	github.com/miekg/dns v1.1.61
 	github.com/pterm/pterm v0.12.79
 	github.com/sirupsen/logrus v1.9.3
@@ -17,7 +16,6 @@ require (
 	atomicgo.dev/schedule v0.1.0 // indirect
 	github.com/containerd/console v1.0.3 // indirect
 	github.com/gookit/color v1.5.4 // indirect
-	github.com/likexian/gokit v0.25.15 // indirect
 	github.com/lithammer/fuzzysearch v1.1.8 // indirect
 	github.com/mattn/go-runewidth v0.0.15 // indirect
 	github.com/rivo/uniseg v0.4.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -33,10 +33,6 @@ github.com/klauspost/cpuid/v2 v2.2.3/go.mod h1:RVVoqg1df56z8g3pUjL/3lE5UfnlrJX8t
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
-github.com/likexian/doh v0.7.1 h1:0p75orMxXrfGNAOnOEtl2xZ5T9Ctqi++i/WhN6P6hs8=
-github.com/likexian/doh v0.7.1/go.mod h1:aIEOK197o6nC82iRo5+5L5ws+X7xRCmuer3M4In91WA=
-github.com/likexian/gokit v0.25.15 h1:QjospM1eXhdMMHwZRpMKKAHY/Wig9wgcREmLtf9NslY=
-github.com/likexian/gokit v0.25.15/go.mod h1:S2QisdsxLEHWeD/XI0QMVeggp+jbxYqUxMvSBil7MRg=
 github.com/lithammer/fuzzysearch v1.1.8 h1:/HIuJnjHuXS8bKaiTMeeDlW2/AyIWk2brx1V8LFgLN4=
 github.com/lithammer/fuzzysearch v1.1.8/go.mod h1:IdqeyBClc3FFqSzYq/MXESsS4S0FsZ5ajtkr5xPLts4=
 github.com/mattn/go-runewidth v0.0.13/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=


### PR DESCRIPTION
Note: May have performance implication. Please review before merge.

Closes #114 

Move the DoH Client completely internally. We now use the `-dns-addr` argument as the DoH server when `-enable-doh` is on, and drop the dependency on likexian's `doh` package (which didn't implement IETF doh and thus won't work with certain providers (eg. `dns.google/dns-query` or `dns.quad9.net`)