### PR TITLE
perf: reuse allocated buffer

### DIFF
--- a/proxy/client_hello.go
+++ b/proxy/client_hello.go
@@ -1,0 +1,48 @@
+package proxy
+
+import (
+	"encoding/binary"
+	"io"
+)
+
+const headerLen = 5
+
+type ClientHello struct {
+	Header     ClientHelloHeader
+	Raw        []byte //Header + Payload
+	RawHeader  []byte
+	RawPayload []byte
+}
+
+type ClientHelloHeader struct {
+	Type         byte
+	ProtoVersion uint16
+	PayloadLen   uint16
+}
+
+func ReadClientHello(r io.Reader) (*ClientHello, error) {
+	var rawHeader [5]byte
+	_, err := io.ReadFull(r, rawHeader[:])
+	if err != nil {
+		return nil, err
+	}
+
+	header := ClientHelloHeader{
+		Type:         rawHeader[0],
+		ProtoVersion: binary.BigEndian.Uint16(rawHeader[1:3]),
+		PayloadLen:   binary.BigEndian.Uint16(rawHeader[3:5]),
+	}
+	raw := make([]byte, header.PayloadLen+headerLen)
+	copy(raw[0:headerLen], rawHeader[:])
+	_, err = io.ReadFull(r, raw[headerLen:])
+	if err != nil {
+		return nil, err
+	}
+	hello := &ClientHello{
+		Header: header,
+		Raw:    raw,
+	}
+	hello.RawHeader = hello.Raw[:headerLen]
+	hello.RawPayload = hello.Raw[headerLen:]
+	return hello, nil
+}

--- a/proxy/client_hello.go
+++ b/proxy/client_hello.go
@@ -7,28 +7,39 @@ import (
 
 const headerLen = 5
 
-type ClientHello struct {
-	Header     ClientHelloHeader
+type TLSMessageType byte
+
+const (
+	TLSInvalid          TLSMessageType = 0x0
+	TLSChangeCipherSpec TLSMessageType = 0x14
+	TLSAlert            TLSMessageType = 0x15
+	TLSHandshake        TLSMessageType = 0x16
+	TLSApplicationData  TLSMessageType = 0x17
+	TLSHeartbeat        TLSMessageType = 0x18
+)
+
+type TlsMessage struct {
+	Header     TlsHeader
 	Raw        []byte //Header + Payload
 	RawHeader  []byte
 	RawPayload []byte
 }
 
-type ClientHelloHeader struct {
-	Type         byte
-	ProtoVersion uint16
+type TlsHeader struct {
+	Type         TLSMessageType
+	ProtoVersion uint16 // major | minor
 	PayloadLen   uint16
 }
 
-func ReadClientHello(r io.Reader) (*ClientHello, error) {
+func ReadTlsMessage(r io.Reader) (*TlsMessage, error) {
 	var rawHeader [5]byte
 	_, err := io.ReadFull(r, rawHeader[:])
 	if err != nil {
 		return nil, err
 	}
 
-	header := ClientHelloHeader{
-		Type:         rawHeader[0],
+	header := TlsHeader{
+		Type:         TLSMessageType(rawHeader[0]),
 		ProtoVersion: binary.BigEndian.Uint16(rawHeader[1:3]),
 		PayloadLen:   binary.BigEndian.Uint16(rawHeader[3:5]),
 	}
@@ -38,11 +49,18 @@ func ReadClientHello(r io.Reader) (*ClientHello, error) {
 	if err != nil {
 		return nil, err
 	}
-	hello := &ClientHello{
-		Header: header,
-		Raw:    raw,
+	hello := &TlsMessage{
+		Header:     header,
+		Raw:        raw,
+		RawHeader:  raw[:headerLen],
+		RawPayload: raw[headerLen:],
 	}
-	hello.RawHeader = hello.Raw[:headerLen]
-	hello.RawPayload = hello.Raw[headerLen:]
 	return hello, nil
+}
+
+func IsClientHello(message *TlsMessage) bool {
+	// According to RFC 8446 section 4.
+	// first byte (Raw[5]) of handshake message should be 0x1 - means client_hello
+	return message.Header.Type == TLSHandshake &&
+		message.Raw[5] == 0x1
 }

--- a/proxy/http.go
+++ b/proxy/http.go
@@ -39,7 +39,7 @@ func (pxy *Proxy) handleHttp(lConn *net.TCPConn, pkt *packet.HttpPacket, ip stri
 
 	log.Debug("[HTTP] New connection to the server ", pkt.Domain(), " ", rConn.LocalAddr())
 
-	go Serve(rConn, lConn, "[HTTP]", lConn.RemoteAddr().String(), pkt.Domain(), pxy.timeout)
+	go Serve(rConn, lConn, "[HTTP]", lConn.RemoteAddr().String(), pkt.Domain(), pxy.timeout, pxy.bufferSize)
 
 	_, err = rConn.Write(pkt.Raw())
 	if err != nil {
@@ -49,5 +49,5 @@ func (pxy *Proxy) handleHttp(lConn *net.TCPConn, pkt *packet.HttpPacket, ip stri
 
 	log.Debug("[HTTP] Sent a request to ", pkt.Domain())
 
-	Serve(lConn, rConn, "[HTTP]", lConn.RemoteAddr().String(), pkt.Domain(), pxy.timeout)
+	Serve(lConn, rConn, "[HTTP]", lConn.RemoteAddr().String(), pkt.Domain(), pxy.timeout, pxy.bufferSize)
 }

--- a/proxy/https.go
+++ b/proxy/https.go
@@ -45,7 +45,7 @@ func (pxy *Proxy) handleHttps(lConn *net.TCPConn, exploit bool, initPkt *packet.
 	log.Debug("[HTTPS] Sent 200 Connection Estabalished to ", lConn.RemoteAddr())
 
 	// Read client hello
-	tmpBuffer := make([]byte, pxy.bufferSize)
+	tmpBuffer := make([]byte, 4096)
 	clientHello, err := ReadBytes(lConn, tmpBuffer)
 	if err != nil {
 		log.Debug("[HTTPS] Error reading client hello from the client", err)

--- a/proxy/https.go
+++ b/proxy/https.go
@@ -45,12 +45,12 @@ func (pxy *Proxy) handleHttps(lConn *net.TCPConn, exploit bool, initPkt *packet.
 	log.Debug("[HTTPS] Sent 200 Connection Estabalished to ", lConn.RemoteAddr())
 
 	// Read client hello
-	hello, err := ReadClientHello(lConn)
-	if err != nil {
+	m, err := ReadTlsMessage(lConn)
+	if err != nil || !IsClientHello(m) {
 		log.Debug("[HTTPS] Error reading client hello from the client", err)
 		return
 	}
-	clientHello := hello.Raw
+	clientHello := m.Raw
 
 	log.Debug("[HTTPS] Client sent hello ", len(clientHello), "bytes")
 

--- a/proxy/https.go
+++ b/proxy/https.go
@@ -45,12 +45,12 @@ func (pxy *Proxy) handleHttps(lConn *net.TCPConn, exploit bool, initPkt *packet.
 	log.Debug("[HTTPS] Sent 200 Connection Estabalished to ", lConn.RemoteAddr())
 
 	// Read client hello
-	tmpBuffer := make([]byte, 4096)
-	clientHello, err := ReadBytes(lConn, tmpBuffer)
+	hello, err := ReadClientHello(lConn)
 	if err != nil {
 		log.Debug("[HTTPS] Error reading client hello from the client", err)
 		return
 	}
+	clientHello := hello.Raw
 
 	log.Debug("[HTTPS] Client sent hello ", len(clientHello), "bytes")
 

--- a/proxy/https.go
+++ b/proxy/https.go
@@ -45,7 +45,8 @@ func (pxy *Proxy) handleHttps(lConn *net.TCPConn, exploit bool, initPkt *packet.
 	log.Debug("[HTTPS] Sent 200 Connection Estabalished to ", lConn.RemoteAddr())
 
 	// Read client hello
-	clientHello, err := ReadBytes(lConn)
+	tmpBuffer := make([]byte, pxy.bufferSize)
+	clientHello, err := ReadBytes(lConn, tmpBuffer)
 	if err != nil {
 		log.Debug("[HTTPS] Error reading client hello from the client", err)
 		return
@@ -60,7 +61,7 @@ func (pxy *Proxy) handleHttps(lConn *net.TCPConn, exploit bool, initPkt *packet.
 	// lConn.SetLinger(3)
 	// rConn.SetLinger(3)
 
-	go Serve(rConn, lConn, "[HTTPS]", rConn.RemoteAddr().String(), initPkt.Domain(), pxy.timeout)
+	go Serve(rConn, lConn, "[HTTPS]", rConn.RemoteAddr().String(), initPkt.Domain(), pxy.timeout, pxy.bufferSize)
 
 	if exploit {
 		log.Debug("[HTTPS] Writing chunked client hello to ", initPkt.Domain())
@@ -77,7 +78,7 @@ func (pxy *Proxy) handleHttps(lConn *net.TCPConn, exploit bool, initPkt *packet.
 		}
 	}
 
-	Serve(lConn, rConn, "[HTTPS]", lConn.RemoteAddr().String(), initPkt.Domain(), pxy.timeout)
+	Serve(lConn, rConn, "[HTTPS]", lConn.RemoteAddr().String(), initPkt.Domain(), pxy.timeout, pxy.bufferSize)
 }
 
 func splitInChunks(bytes []byte, size int) [][]byte {

--- a/proxy/io.go
+++ b/proxy/io.go
@@ -28,24 +28,17 @@ func ReadBytes(conn *net.TCPConn, dest []byte) ([]byte, error) {
 	return dest[:n], err
 }
 
-func readBytesInternal(in io.Reader, dest []byte) (int, error) {
-	totalRead := 0
-	for {
-		numRead, readErr := in.Read(dest[totalRead:])
-		totalRead += numRead
-		if readErr != nil {
-			switch readErr.(type) {
-			case *net.OpError:
-				return totalRead, errors.New("timed out")
-			default:
-				return totalRead, readErr
-			}
+func readBytesInternal(conn *net.TCPConn, dest []byte) (int, error) {
+	totalRead, err := conn.Read(dest)
+	if err != nil {
+		switch err.(type) {
+		case *net.OpError:
+			return totalRead, errors.New("timed out")
+		default:
+			return totalRead, err
 		}
-		if totalRead == 0 {
-			return 0, io.EOF
-		}
-		return totalRead, nil
 	}
+	return totalRead, nil
 }
 
 func Serve(from *net.TCPConn, to *net.TCPConn, proto string, fd string, td string, timeout int, bufferSize int) {

--- a/proxy/io.go
+++ b/proxy/io.go
@@ -9,8 +9,6 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-const BUF_SIZE = 1024
-
 func WriteChunks(conn *net.TCPConn, c [][]byte) (n int, err error) {
 	total := 0
 	for i := 0; i < len(c); i++ {
@@ -25,45 +23,42 @@ func WriteChunks(conn *net.TCPConn, c [][]byte) (n int, err error) {
 	return total, nil
 }
 
-func ReadBytes(conn *net.TCPConn) ([]byte, error) {
-	ret := make([]byte, 0)
-	buf := make([]byte, BUF_SIZE)
-
-	for {
-		n, err := conn.Read(buf)
-		if err != nil {
-			switch err.(type) {
-			case *net.OpError:
-				return nil, errors.New("timed out")
-			default:
-				return nil, err
-			}
-		}
-		ret = append(ret, buf[:n]...)
-
-		if n < BUF_SIZE {
-			break
-		}
-	}
-
-	if len(ret) == 0 {
-		return nil, io.EOF
-	}
-
-	return ret, nil
+func ReadBytes(conn *net.TCPConn, dest []byte) ([]byte, error) {
+	n, err := readBytesInternal(conn, dest)
+	return dest[:n], err
 }
 
-func Serve(from *net.TCPConn, to *net.TCPConn, proto string, fd string, td string, timeout int) {
-	proto += " "
-
+func readBytesInternal(in io.Reader, dest []byte) (int, error) {
+	totalRead := 0
 	for {
-    if timeout > 0 {
-      from.SetReadDeadline(
-        time.Now().Add(time.Millisecond * time.Duration(timeout)),
-      )
-    }
+		numRead, readErr := in.Read(dest[totalRead:])
+		totalRead += numRead
+		if readErr != nil {
+			switch readErr.(type) {
+			case *net.OpError:
+				return totalRead, errors.New("timed out")
+			default:
+				return totalRead, readErr
+			}
+		}
+		if totalRead == 0 {
+			return 0, io.EOF
+		}
+		return totalRead, nil
+	}
+}
 
-		buf, err := ReadBytes(from)
+func Serve(from *net.TCPConn, to *net.TCPConn, proto string, fd string, td string, timeout int, bufferSize int) {
+	proto += " "
+	buf := make([]byte, bufferSize)
+	for {
+		if timeout > 0 {
+			from.SetReadDeadline(
+				time.Now().Add(time.Millisecond * time.Duration(timeout)),
+			)
+		}
+
+		bytesRead, err := ReadBytes(from, buf)
 		if err != nil {
 			if err == io.EOF {
 				log.Debug(proto, "Finished ", fd)
@@ -73,7 +68,7 @@ func Serve(from *net.TCPConn, to *net.TCPConn, proto string, fd string, td strin
 			return
 		}
 
-		if _, err := to.Write(buf); err != nil {
+		if _, err := to.Write(bytesRead); err != nil {
 			log.Debug(proto, "Error Writing to ", td)
 			return
 		}

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -13,6 +13,8 @@ import (
 	"github.com/xvzc/SpoofDPI/util"
 )
 
+const BUFFER_SIZE = 1024
+
 type Proxy struct {
 	addr           string
 	port           int
@@ -31,7 +33,7 @@ func New(config *util.Config) *Proxy {
 		windowSize:     *config.WindowSize,
 		allowedPattern: config.AllowedPattern,
 		resolver:       dns.NewResolver(config),
-		bufferSize:     *config.BufferSize,
+		bufferSize:     BUFFER_SIZE,
 	}
 }
 

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -59,17 +59,15 @@ func (pxy *Proxy) Start() {
 		}
 
 		go func() {
-			tmpBuf := make([]byte, pxy.bufferSize)
-			b, err := ReadBytes(conn.(*net.TCPConn), tmpBuf)
+			pkt, err := packet.NewHttpPacketFromReader(conn)
 			if err != nil {
 				return
 			}
 
-			log.Debug("[PROXY] Request from ", conn.RemoteAddr(), "\n\n", string(b))
+			log.Debug("[PROXY] Request from ", conn.RemoteAddr(), "\n\n", string(pkt.Raw()))
 
-			pkt, err := packet.NewHttpPacket(b)
 			if err != nil {
-				log.Debug("[PROXY] Error while parsing request: ", string(b))
+				log.Debug("[PROXY] Error while parsing request: ", string(pkt.Raw()))
 				conn.Close()
 				return
 			}

--- a/util/config.go
+++ b/util/config.go
@@ -22,7 +22,6 @@ type Config struct {
 	AllowedPattern []*regexp.Regexp
 	WindowSize     *int
 	Version        *bool
-	BufferSize     *int
 }
 
 type StringArray []string
@@ -59,7 +58,6 @@ when not given, the client hello packet will be sent in two parts:
 fragmentation for the first data packet and the rest
 `)
 	config.Version = flag.Bool("v", false, "print spoof-dpi's version; this may contain some other relevant information")
-	config.BufferSize = flag.Int("buffer-size", 1024, "buffer size, in number of bytes, is the maximum amount of data that can be read at once from a remote resource")
 	var allowedPattern StringArray
 	flag.Var(
 		&allowedPattern,

--- a/util/config.go
+++ b/util/config.go
@@ -22,6 +22,7 @@ type Config struct {
 	AllowedPattern []*regexp.Regexp
 	WindowSize     *int
 	Version        *bool
+	BufferSize     *int
 }
 
 type StringArray []string
@@ -58,7 +59,7 @@ when not given, the client hello packet will be sent in two parts:
 fragmentation for the first data packet and the rest
 `)
 	config.Version = flag.Bool("v", false, "print spoof-dpi's version; this may contain some other relevant information")
-
+	config.BufferSize = flag.Int("buffer-size", 1024, "buffer size, in number of bytes, is the maximum amount of data that can be read at once from a remote resource")
 	var allowedPattern StringArray
 	flag.Var(
 		&allowedPattern,


### PR DESCRIPTION
Tested the latest update a bit #119  I realized that there is now a small problem with reading the client hello. If the client hello is larger than 1024 bytes, it will not be read in its entirety. I apologize for my mistake