### PR TITLE
fix: IPv6 support

### DIFF
--- a/cmd/spoof-dpi/main.go
+++ b/cmd/spoof-dpi/main.go
@@ -13,14 +13,14 @@ import (
 )
 
 func main() {
-  args := util.ParseArgs()
+	args := util.ParseArgs()
 	if *args.Version {
 		version.PrintVersion()
 		os.Exit(0)
 	}
 
 	config := util.GetConfig()
-  config.Load(args)
+	config.Load(args)
 
 	pxy := proxy.New(config)
 	if *config.Debug {
@@ -41,7 +41,7 @@ func main() {
 
 	if *config.SystemProxy {
 		if err := util.SetOsProxy(*config.Port); err != nil {
-			log.Fatal("error while changing proxy settings")
+			log.Fatalf("error while changing proxy settings: %s", err)
 		}
 	}
 

--- a/dns/resolver/doh.go
+++ b/dns/resolver/doh.go
@@ -33,7 +33,11 @@ func NewDOHResolver(host string) *DOHResolver {
 		},
 	}
 
-	host = regexp.MustCompile(`^https:\/\/|\/dns-query$`).ReplaceAllString(host, "")
+	host = regexp.MustCompile(`^https://|/dns-query$`).ReplaceAllString(host, "")
+	if ip := net.ParseIP(host); ip != nil && ip.To4() == nil {
+		host = fmt.Sprintf("[%s]", ip)
+	}
+
 	return &DOHResolver{
 		upstream: "https://" + host + "/dns-query",
 		client:   c,


### PR DESCRIPTION
- Fixes an error that arises while setting up proxy on an IPv6-only machine.
- Fixes incorrect URL building that happens when an IPv6 address is passed to the DoH client instead of a hostname.