### PR TITLE
fix: proxy settings are not reverted after panic

### DIFF
--- a/cmd/spoof-dpi/main.go
+++ b/cmd/spoof-dpi/main.go
@@ -38,6 +38,11 @@ func main() {
 		if err := util.SetOsProxy(*config.Port); err != nil {
 			logger.Fatal().Msgf("error while changing proxy settings: %s", err)
 		}
+		defer func() {
+			if err := util.UnsetOsProxy(); err != nil {
+				logger.Fatal().Msgf("error while disabling proxy: %s", err)
+			}
+		}()
 	}
 
 	go pxy.Start(context.Background())
@@ -60,10 +65,4 @@ func main() {
 	}()
 
 	<-done
-
-	if *config.SystemProxy {
-		if err := util.UnsetOsProxy(); err != nil {
-			logger.Fatal().Msgf("%s", err)
-		}
-	}
 }


### PR DESCRIPTION
Fixes #181.
Will mark as ready after #182 is merged. They diverged a bit.