### PR TITLE
chore: refactor args

### DIFF
--- a/cmd/spoof-dpi/main.go
+++ b/cmd/spoof-dpi/main.go
@@ -2,10 +2,11 @@ package main
 
 import (
 	"context"
-	"github.com/xvzc/SpoofDPI/util/log"
 	"os"
 	"os/signal"
 	"syscall"
+
+	"github.com/xvzc/SpoofDPI/util/log"
 
 	"github.com/xvzc/SpoofDPI/proxy"
 	"github.com/xvzc/SpoofDPI/util"
@@ -14,7 +15,7 @@ import (
 
 func main() {
 	args := util.ParseArgs()
-	if *args.Version {
+	if args.Version {
 		version.PrintVersion()
 		os.Exit(0)
 	}
@@ -28,14 +29,14 @@ func main() {
 
 	pxy := proxy.New(config)
 
-	if *config.NoBanner {
+	if config.NoBanner {
 		util.PrintSimpleInfo()
 	} else {
 		util.PrintColoredBanner()
 	}
 
-	if *config.SystemProxy {
-		if err := util.SetOsProxy(*config.Port); err != nil {
+	if config.SystemProxy {
+		if err := util.SetOsProxy(config.Port); err != nil {
 			logger.Fatal().Msgf("error while changing proxy settings: %s", err)
 		}
 		defer func() {

--- a/dns/dns.go
+++ b/dns/dns.go
@@ -29,11 +29,11 @@ type Dns struct {
 }
 
 func NewDns(config *util.Config) *Dns {
-	addr := *config.DnsAddr
-	port := strconv.Itoa(*config.DnsPort)
+	addr := config.DnsAddr
+	port := strconv.Itoa(config.DnsPort)
 
 	return &Dns{
-		host:          *config.DnsAddr,
+		host:          config.DnsAddr,
 		port:          port,
 		systemClient:  resolver.NewSystemResolver(),
 		generalClient: resolver.NewGeneralResolver(net.JoinHostPort(addr, port)),

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -27,11 +27,11 @@ type Proxy struct {
 
 func New(config *util.Config) *Proxy {
 	return &Proxy{
-		addr:           *config.Addr,
-		port:           *config.Port,
-		timeout:        *config.Timeout,
-		windowSize:     *config.WindowSize,
-		enableDoh:      *config.EnableDoh,
+		addr:           config.Addr,
+		port:           config.Port,
+		timeout:        config.Timeout,
+		windowSize:     config.WindowSize,
+		enableDoh:      config.EnableDoh,
 		allowedPattern: config.AllowedPatterns,
 		resolver:       dns.NewDns(config),
 	}

--- a/util/args.go
+++ b/util/args.go
@@ -6,18 +6,18 @@ import (
 )
 
 type Args struct {
-	Addr           *string
-	Port           *int
-	DnsAddr        *string
-	DnsPort        *int
-	EnableDoh      *bool
-	Debug          *bool
-	NoBanner       *bool
-	SystemProxy    *bool
-	Timeout        *int
-	AllowedPattern *StringArray
-	WindowSize     *int
-	Version        *bool
+	Addr           string
+	Port           int
+	DnsAddr        string
+	DnsPort        int
+	EnableDoh      bool
+	Debug          bool
+	NoBanner       bool
+	SystemProxy    bool
+	Timeout        int
+	AllowedPattern StringArray
+	WindowSize     int
+	Version        bool
 }
 
 type StringArray []string
@@ -33,25 +33,24 @@ func (arr *StringArray) Set(value string) error {
 
 func ParseArgs() *Args {
 	args := new(Args)
-	args.Addr = flag.String("addr", "127.0.0.1", "listen address")
-	args.Port = flag.Int("port", 8080, "port")
-	args.DnsAddr = flag.String("dns-addr", "8.8.8.8", "dns address")
-	args.DnsPort = flag.Int("dns-port", 53, "port number for dns")
-	args.EnableDoh = flag.Bool("enable-doh", false, "enable 'dns-over-https'")
-	args.Debug = flag.Bool("debug", false, "enable debug output")
-	args.NoBanner = flag.Bool("no-banner", false, "disable banner")
-	args.SystemProxy = flag.Bool("system-proxy", true, "enable system-wide proxy")
-	args.Timeout = flag.Int("timeout", 0, "timeout in milliseconds; no timeout when not given")
-	args.WindowSize = flag.Int("window-size", 0, `chunk size, in number of bytes, for fragmented client hello,
+
+	flag.StringVar(&args.Addr, "addr", "127.0.0.1", "listen address")
+	flag.IntVar(&args.Port, "port", 8080, "port")
+	flag.StringVar(&args.DnsAddr, "dns-addr", "8.8.8.8", "dns address")
+	flag.IntVar(&args.DnsPort, "dns-port", 53, "port number for dns")
+	flag.BoolVar(&args.EnableDoh, "enable-doh", false, "enable 'dns-over-https'")
+	flag.BoolVar(&args.Debug, "debug", false, "enable debug output")
+	flag.BoolVar(&args.NoBanner, "no-banner", false, "disable banner")
+	flag.BoolVar(&args.SystemProxy, "system-proxy", true, "enable system-wide proxy")
+	flag.IntVar(&args.Timeout, "timeout", 0, "timeout in milliseconds; no timeout when not given")
+	flag.IntVar(&args.WindowSize, "window-size", 0, `chunk size, in number of bytes, for fragmented client hello,
 try lower values if the default value doesn't bypass the DPI;
 when not given, the client hello packet will be sent in two parts:
 fragmentation for the first data packet and the rest
 `)
-  args.AllowedPattern = new(StringArray)
-	args.Version = flag.Bool("v", false, "print spoof-dpi's version; this may contain some other relevant information")
-
+	flag.BoolVar(&args.Version, "v", false, "print spoof-dpi's version; this may contain some other relevant information")
 	flag.Var(
-		args.AllowedPattern,
+		&args.AllowedPattern,
 		"pattern",
 		"bypass DPI only on packets matching this regex pattern; can be given multiple times",
 	)

--- a/util/config.go
+++ b/util/config.go
@@ -9,16 +9,16 @@ import (
 )
 
 type Config struct {
-	Addr            *string
-	Port            *int
-	DnsAddr         *string
-	DnsPort         *int
-	EnableDoh       *bool
-	Debug           *bool
-	NoBanner        *bool
-	SystemProxy     *bool
-	Timeout         *int
-	WindowSize      *int
+	Addr            string
+	Port            int
+	DnsAddr         string
+	DnsPort         int
+	EnableDoh       bool
+	Debug           bool
+	NoBanner        bool
+	SystemProxy     bool
+	Timeout         int
+	WindowSize      int
 	AllowedPatterns []*regexp.Regexp
 }
 
@@ -45,10 +45,10 @@ func (c *Config) Load(args *Args) {
 	c.WindowSize = args.WindowSize
 }
 
-func parseAllowedPattern(patterns *StringArray) []*regexp.Regexp {
+func parseAllowedPattern(patterns StringArray) []*regexp.Regexp {
 	var allowedPatterns []*regexp.Regexp
 
-	for _, pattern := range *patterns {
+	for _, pattern := range patterns {
 		allowedPatterns = append(allowedPatterns, regexp.MustCompile(pattern))
 	}
 
@@ -61,18 +61,18 @@ func PrintColoredBanner() {
 	pterm.DefaultBigText.WithLetters(cyan, purple).Render()
 
 	pterm.DefaultBulletList.WithItems([]pterm.BulletListItem{
-		{Level: 0, Text: "ADDR    : " + fmt.Sprint(*config.Addr)},
-		{Level: 0, Text: "PORT    : " + fmt.Sprint(*config.Port)},
-		{Level: 0, Text: "DNS     : " + fmt.Sprint(*config.DnsAddr)},
-		{Level: 0, Text: "DEBUG   : " + fmt.Sprint(*config.Debug)},
+		{Level: 0, Text: "ADDR    : " + fmt.Sprint(config.Addr)},
+		{Level: 0, Text: "PORT    : " + fmt.Sprint(config.Port)},
+		{Level: 0, Text: "DNS     : " + fmt.Sprint(config.DnsAddr)},
+		{Level: 0, Text: "DEBUG   : " + fmt.Sprint(config.Debug)},
 	}).Render()
 }
 
 func PrintSimpleInfo() {
 	fmt.Println("")
-	fmt.Println("- ADDR    : ", *config.Addr)
-	fmt.Println("- PORT    : ", *config.Port)
-	fmt.Println("- DNS     : ", *config.DnsAddr)
-	fmt.Println("- DEBUG   : ", *config.Debug)
+	fmt.Println("- ADDR    : ", config.Addr)
+	fmt.Println("- PORT    : ", config.Port)
+	fmt.Println("- DNS     : ", config.DnsAddr)
+	fmt.Println("- DEBUG   : ", config.Debug)
 	fmt.Println("")
 }

--- a/util/log/log.go
+++ b/util/log/log.go
@@ -3,10 +3,11 @@ package log
 import (
 	"context"
 	"fmt"
-	"github.com/rs/zerolog"
-	"github.com/xvzc/SpoofDPI/util"
 	"os"
 	"time"
+
+	"github.com/rs/zerolog"
+	"github.com/xvzc/SpoofDPI/util"
 )
 
 const (
@@ -42,7 +43,7 @@ func InitLogger(cfg *util.Config) {
 	}
 
 	logger = zerolog.New(consoleWriter).Hook(ctxHook{})
-	if *cfg.Debug {
+	if cfg.Debug {
 		logger = logger.Level(zerolog.DebugLevel)
 	} else {
 		logger = logger.Level(zerolog.InfoLevel)


### PR DESCRIPTION
The pointer fields have been converted to the usual ones in the ARGS structure for convenience.