### PR TITLE
Add anti-pattern CLI param; like pattern, but opposite

### DIFF
--- a/dns/dns.go
+++ b/dns/dns.go
@@ -53,7 +53,7 @@ func (d *Dns) ResolveHost(ctx context.Context, host string, enableDoh bool, useS
 	ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
 	defer cancel()
 
-	logger.Info().Msgf("resolving %s using %s", host, clt)
+	logger.Debug().Msgf("resolving %s using %s", host, clt)
 
 	t := time.Now()
 

--- a/dns/dns.go
+++ b/dns/dns.go
@@ -53,7 +53,7 @@ func (d *Dns) ResolveHost(ctx context.Context, host string, enableDoh bool, useS
 	ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
 	defer cancel()
 
-	logger.Debug().Msgf("resolving %s using %s", host, clt)
+	logger.Info().Msgf("resolving %s using %s", host, clt)
 
 	t := time.Now()
 

--- a/util/args.go
+++ b/util/args.go
@@ -6,18 +6,19 @@ import (
 )
 
 type Args struct {
-	Addr           string
-	Port           int
-	DnsAddr        string
-	DnsPort        int
-	EnableDoh      bool
-	Debug          bool
-	NoBanner       bool
-	SystemProxy    bool
-	Timeout        int
-	AllowedPattern StringArray
-	WindowSize     int
-	Version        bool
+	Addr             string
+	Port             int
+	DnsAddr          string
+	DnsPort          int
+	EnableDoh        bool
+	Debug            bool
+	NoBanner         bool
+	SystemProxy      bool
+	Timeout          int
+	AllowedPattern   StringArray
+	UnallowedPattern StringArray
+	WindowSize       int
+	Version          bool
 }
 
 type StringArray []string
@@ -53,6 +54,11 @@ fragmentation for the first data packet and the rest
 		&args.AllowedPattern,
 		"pattern",
 		"bypass DPI only on packets matching this regex pattern; can be given multiple times",
+	)
+	flag.Var(
+		&args.UnallowedPattern,
+		"anti-pattern",
+		"bypass DPI on all packets except matching this regex pattern; can be given multiple times",
 	)
 
 	flag.Parse()

--- a/util/config.go
+++ b/util/config.go
@@ -9,17 +9,18 @@ import (
 )
 
 type Config struct {
-	Addr            string
-	Port            int
-	DnsAddr         string
-	DnsPort         int
-	EnableDoh       bool
-	Debug           bool
-	NoBanner        bool
-	SystemProxy     bool
-	Timeout         int
-	WindowSize      int
-	AllowedPatterns []*regexp.Regexp
+	Addr              string
+	Port              int
+	DnsAddr           string
+	DnsPort           int
+	EnableDoh         bool
+	Debug             bool
+	NoBanner          bool
+	SystemProxy       bool
+	Timeout           int
+	WindowSize        int
+	AllowedPatterns   []*regexp.Regexp
+	UnallowedPatterns []*regexp.Regexp
 }
 
 var config *Config
@@ -41,18 +42,19 @@ func (c *Config) Load(args *Args) {
 	c.NoBanner = args.NoBanner
 	c.SystemProxy = args.SystemProxy
 	c.Timeout = args.Timeout
-	c.AllowedPatterns = parseAllowedPattern(args.AllowedPattern)
+	c.AllowedPatterns = parsePattern(args.AllowedPattern)
+	c.UnallowedPatterns = parsePattern(args.UnallowedPattern)
 	c.WindowSize = args.WindowSize
 }
 
-func parseAllowedPattern(patterns StringArray) []*regexp.Regexp {
-	var allowedPatterns []*regexp.Regexp
+func parsePattern(patterns StringArray) []*regexp.Regexp {
+	var result []*regexp.Regexp
 
 	for _, pattern := range patterns {
-		allowedPatterns = append(allowedPatterns, regexp.MustCompile(pattern))
+		result = append(result, regexp.MustCompile(pattern))
 	}
 
-	return allowedPatterns
+	return result
 }
 
 func PrintColoredBanner() {


### PR DESCRIPTION
The new `-anti-pattern` parameter works the same as `-pattern`, but with precision, the other way around: if it is specified, dpi bypass is applied to everything that does not match the template