### PR TITLE
chore: increase the length of traceId token

### DIFF
--- a/util/context.go
+++ b/util/context.go
@@ -47,7 +47,7 @@ func generateTraceId() string {
 			r += 0x27
 		}
 		sb.WriteByte(r + 0x30)
-		if i&3 == 3 && i != 31 {
+		if i&7 == 7 && i != 31 {
 			sb.WriteByte(0x2D)
 		}
 	}

--- a/util/context.go
+++ b/util/context.go
@@ -34,7 +34,7 @@ func GetTraceIdFromCtx(ctx context.Context) (string, bool) {
 
 func generateTraceId() string {
 	sb := strings.Builder{}
-	sb.Grow(22)
+	sb.Grow(35)
 
 	var q uint64
 	var r uint8


### PR DESCRIPTION
The previouse format of trace id was being separated to much not very neccesarrily. Increased the size of token to 8 instead of 4