### PR TITLE
fix: get ctx logger on new request

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -65,6 +65,7 @@ func (pxy *Proxy) Start(ctx context.Context) {
 
 		go func() {
 			ctx := util.GetCtxWithTraceId(ctx)
+			logger := log.GetCtxLogger(ctx)
 
 			pkt, err := packet.ReadHttpRequest(conn)
 			if err != nil {

--- a/util/log/log.go
+++ b/util/log/log.go
@@ -23,8 +23,8 @@ func GetCtxLogger(ctx context.Context) zerolog.Logger {
 
 func InitLogger(cfg *util.Config) {
 	partsOrder := []string{
-		zerolog.TimestampFieldName,
 		zerolog.LevelFieldName,
+		zerolog.TimestampFieldName,
 		traceIdFieldName,
 		scopeFieldName,
 		zerolog.MessageFieldName,


### PR DESCRIPTION
We need to get ctx logger again when getting a new request so that the proxy logger can show the traceId. Also, changed log format to show the log level for the first.