### PR TITLE
Use Google Distroless for compact images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,7 @@
 FROM golang:alpine as builder
-
 WORKDIR /go
-
 RUN go install github.com/xvzc/SpoofDPI/cmd/spoofdpi@latest
 
-FROM alpine:latest
-
-WORKDIR /
-
-COPY --from=builder /go/bin/spoofdpi .
-
-ENTRYPOINT ["./spoofdpi"]
+FROM gcr.io/distroless/static-debian12
+COPY --from=builder /go/bin/spoofdpi /
+ENTRYPOINT ["/spoofdpi"]


### PR DESCRIPTION
I'm using Google Distroless in [gavrilovegor519/spoofdpi-docker](https://github.com/gavrilovegor519/spoofdpi-docker) project - Docker version of SpoofDPI for using in Russia. This base image very compact (~2 Mb versus ~5-6 Mb of Alpine image), not contains shell and package manager (increases security), and contains virtually no binaries in Static images.