### PR TITLE
fix: packet processing for http request

### DIFF
--- a/proxy/handler/conn.go
+++ b/proxy/handler/conn.go
@@ -1,0 +1,14 @@
+package handler
+
+import (
+	"net"
+	"time"
+)
+
+func setConnectionTimeout(conn *net.TCPConn, timeout int) error {
+	if timeout <= 0 {
+		return nil
+	}
+
+	return conn.SetReadDeadline(time.Now().Add(time.Millisecond * time.Duration(timeout)))
+}

--- a/proxy/handler/http.go
+++ b/proxy/handler/http.go
@@ -1,0 +1,134 @@
+package handler
+
+import (
+	"context"
+	"net"
+	"strconv"
+	"time"
+
+	"github.com/xvzc/SpoofDPI/packet"
+	"github.com/xvzc/SpoofDPI/util"
+	"github.com/xvzc/SpoofDPI/util/log"
+)
+
+type HttpHandler struct {
+	bufferSize int
+	protocol   string
+	port       int
+	timeout    int
+}
+
+func NewHttpHandler(timeout int) *HttpHandler {
+	return &HttpHandler{
+		bufferSize: 1024,
+		protocol:   "HTTP",
+		port:       80,
+		timeout:    timeout,
+	}
+}
+
+func (h *HttpHandler) Serve(ctx context.Context, lConn *net.TCPConn, pkt *packet.HttpRequest, ip string) {
+	ctx = util.GetCtxWithScope(ctx, h.protocol)
+	logger := log.GetCtxLogger(ctx)
+
+	// Create a connection to the requested server
+	var port int = 80
+	var err error
+	if pkt.Port() != "" {
+		port, err = strconv.Atoi(pkt.Port())
+		if err != nil {
+			logger.Debug().Msgf("error while parsing port for %s aborting..", pkt.Domain())
+		}
+	}
+
+	rConn, err := net.DialTCP("tcp", nil, &net.TCPAddr{IP: net.ParseIP(ip), Port: port})
+	if err != nil {
+		lConn.Close()
+		logger.Debug().Msgf("%s", err)
+		return
+	}
+
+	logger.Debug().Msgf("new connection to the server %s -> %s", rConn.LocalAddr(), pkt.Domain())
+
+	go h.deliverResponse(ctx, rConn, lConn, pkt.Domain(), lConn.RemoteAddr().String())
+	go h.deliverRequest(ctx, lConn, rConn, lConn.RemoteAddr().String(), pkt.Domain())
+
+	_, err = rConn.Write(pkt.Raw())
+	if err != nil {
+		logger.Debug().Msgf("error sending request to %s: %s", pkt.Domain(), err)
+		return
+	}
+}
+
+func (h *HttpHandler) deliverRequest(
+	ctx context.Context,
+	lConn *net.TCPConn,
+	rConn *net.TCPConn,
+	fd string,
+	td string,
+) {
+	ctx = util.GetCtxWithScope(ctx, h.protocol)
+	logger := log.GetCtxLogger(ctx)
+
+	defer func() {
+		lConn.Close()
+		rConn.Close()
+
+		logger.Debug().Msgf("closing proxy connection: %s -> %s", fd, td)
+	}()
+
+	if h.timeout > 0 {
+		lConn.SetReadDeadline(time.Now().Add(time.Millisecond * time.Duration(h.timeout)))
+	}
+
+	for {
+		pkt, err := packet.ReadHttpRequest(lConn)
+		if err != nil {
+			logger.Debug().Msgf("error reading from %s: %s", fd, err)
+			return
+		}
+
+		pkt.Tidy()
+
+		if _, err := rConn.Write(pkt.Raw()); err != nil {
+			logger.Debug().Msgf("error Writing to %s", td)
+			return
+		}
+	}
+}
+
+func (h *HttpHandler) deliverResponse(
+	ctx context.Context,
+	from *net.TCPConn,
+	to *net.TCPConn,
+	fd string,
+	td string,
+) {
+	ctx = util.GetCtxWithScope(ctx, h.protocol)
+	logger := log.GetCtxLogger(ctx)
+
+	defer func() {
+		from.Close()
+		to.Close()
+
+		logger.Debug().Msgf("closing proxy connection: %s -> %s", fd, td)
+	}()
+
+	buf := make([]byte, h.bufferSize)
+	for {
+		if h.timeout > 0 {
+			from.SetReadDeadline(time.Now().Add(time.Millisecond * time.Duration(h.timeout)))
+		}
+
+		bytesRead, err := ReadBytes(ctx, from, buf)
+		if err != nil {
+			logger.Debug().Msgf("error reading from %s: %s", fd, err)
+			return
+		}
+
+		if _, err := to.Write(bytesRead); err != nil {
+			logger.Debug().Msgf("error Writing to %s", td)
+			return
+		}
+	}
+}

--- a/proxy/handler/https.go
+++ b/proxy/handler/https.go
@@ -1,0 +1,177 @@
+package handler
+
+import (
+	"context"
+	"net"
+	"regexp"
+	"strconv"
+	"time"
+
+	"github.com/xvzc/SpoofDPI/packet"
+	"github.com/xvzc/SpoofDPI/util"
+	"github.com/xvzc/SpoofDPI/util/log"
+)
+
+type HttpsHandler struct {
+	bufferSize      int
+	protocol        string
+	port            int
+	timeout         int
+	windowsize      int
+	exploit         bool
+	allowedPatterns []*regexp.Regexp
+}
+
+func NewHttpsHandler(timeout int, windowSize int, allowedPatterns []*regexp.Regexp, exploit bool) *HttpsHandler {
+	return &HttpsHandler{
+		bufferSize:      1024,
+		protocol:        "HTTPS",
+		port:            443,
+		timeout:         timeout,
+		windowsize:      windowSize,
+		allowedPatterns: allowedPatterns,
+		exploit:         exploit,
+	}
+}
+
+func (h *HttpsHandler) Serve(ctx context.Context, lConn *net.TCPConn, initPkt *packet.HttpRequest, ip string) {
+	ctx = util.GetCtxWithScope(ctx, h.protocol)
+	logger := log.GetCtxLogger(ctx)
+
+	// Create a connection to the requested server
+	var err error
+	if initPkt.Port() != "" {
+		h.port, err = strconv.Atoi(initPkt.Port())
+		if err != nil {
+			logger.Debug().Msgf("error parsing port for %s aborting..", initPkt.Domain())
+		}
+	}
+
+	rConn, err := net.DialTCP("tcp", nil, &net.TCPAddr{IP: net.ParseIP(ip), Port: h.port})
+	if err != nil {
+		lConn.Close()
+		logger.Debug().Msgf("%s", err)
+		return
+	}
+
+	logger.Debug().Msgf("new connection to the server %s -> %s", rConn.LocalAddr(), initPkt.Domain())
+
+	_, err = lConn.Write([]byte(initPkt.Version() + " 200 Connection Established\r\n\r\n"))
+	if err != nil {
+		logger.Debug().Msgf("error sending 200 connection established to the client: %s", err)
+		return
+	}
+
+	logger.Debug().Msgf("sent connection estabalished to %s", lConn.RemoteAddr())
+
+	// Read client hello
+	m, err := packet.ReadTLSMessage(lConn)
+	if err != nil || !m.IsClientHello() {
+		logger.Debug().Msgf("error reading client hello from %s: %s", lConn.RemoteAddr().String(), err)
+		return
+	}
+	clientHello := m.Raw
+
+	logger.Debug().Msgf("client sent hello %d bytes", len(clientHello))
+
+	// Generate a go routine that reads from the server
+	go h.communicate(ctx, rConn, lConn, initPkt.Domain(), lConn.RemoteAddr().String())
+	go h.communicate(ctx, lConn, rConn, lConn.RemoteAddr().String(), initPkt.Domain())
+
+	if h.exploit {
+		logger.Debug().Msgf("writing chunked client hello to %s", initPkt.Domain())
+		chunks := splitInChunks(ctx, clientHello, h.windowsize)
+		if _, err := writeChunks(rConn, chunks); err != nil {
+			logger.Debug().Msgf("error writing chunked client hello to %s: %s", initPkt.Domain(), err)
+			return
+		}
+	} else {
+		logger.Debug().Msgf("writing plain client hello to %s", initPkt.Domain())
+		if _, err := rConn.Write(clientHello); err != nil {
+			logger.Debug().Msgf("error writing plain client hello to %s: %s", initPkt.Domain(), err)
+			return
+		}
+	}
+}
+
+func (h *HttpsHandler) communicate(ctx context.Context, from *net.TCPConn, to *net.TCPConn, fd string, td string) {
+	ctx = util.GetCtxWithScope(ctx, h.protocol)
+	logger := log.GetCtxLogger(ctx)
+
+	defer func() {
+		from.Close()
+		to.Close()
+
+		logger.Debug().Msgf("closing proxy connection: %s -> %s", fd, td)
+	}()
+
+	buf := make([]byte, h.bufferSize)
+	for {
+		if h.timeout > 0 {
+			from.SetReadDeadline(time.Now().Add(time.Millisecond * time.Duration(h.timeout)))
+		}
+
+		bytesRead, err := ReadBytes(ctx, from, buf)
+		if err != nil {
+			logger.Debug().Msgf("error reading from %s: %s", fd, err)
+			return
+		}
+
+		if _, err := to.Write(bytesRead); err != nil {
+			logger.Debug().Msgf("error Writing to %s", td)
+			return
+		}
+	}
+}
+
+func splitInChunks(ctx context.Context, bytes []byte, size int) [][]byte {
+	logger := log.GetCtxLogger(ctx)
+
+	var chunks [][]byte
+	var raw []byte = bytes
+
+	logger.Debug().Msgf("window-size: %d", size)
+
+	if size > 0 {
+		for {
+			if len(raw) == 0 {
+				break
+			}
+
+			// necessary check to avoid slicing beyond
+			// slice capacity
+			if len(raw) < size {
+				size = len(raw)
+			}
+
+			chunks = append(chunks, raw[0:size])
+			raw = raw[size:]
+		}
+
+		return chunks
+	}
+
+	// When the given window-size <= 0
+
+	if len(raw) < 1 {
+		return [][]byte{raw}
+	}
+
+	logger.Debug().Msg("using legacy fragmentation")
+
+	return [][]byte{raw[:1], raw[1:]}
+}
+
+func writeChunks(conn *net.TCPConn, c [][]byte) (n int, err error) {
+	total := 0
+	for i := 0; i < len(c); i++ {
+		b, err := conn.Write(c[i])
+		if err != nil {
+			return 0, nil
+		}
+
+		total += b
+	}
+
+	return total, nil
+}

--- a/proxy/handler/https.go
+++ b/proxy/handler/https.go
@@ -107,8 +107,9 @@ func (h *HttpsHandler) communicate(ctx context.Context, from *net.TCPConn, to *n
 
 	buf := make([]byte, h.bufferSize)
 	for {
-		if h.timeout > 0 {
-			from.SetReadDeadline(time.Now().Add(time.Millisecond * time.Duration(h.timeout)))
+		err := setConnectionTimeout(from, h.timeout)
+		if err != nil {
+			logger.Debug().Msgf("error while setting connection deadline for %s: %s", fd, err)
 		}
 
 		bytesRead, err := ReadBytes(ctx, from, buf)

--- a/proxy/handler/io.go
+++ b/proxy/handler/io.go
@@ -1,0 +1,26 @@
+package handler
+
+import (
+	"context"
+	"errors"
+	"net"
+)
+
+func ReadBytes(ctx context.Context, conn *net.TCPConn, dest []byte) ([]byte, error) {
+	n, err := readBytesInternal(ctx, conn, dest)
+	return dest[:n], err
+}
+
+func readBytesInternal(ctx context.Context, conn *net.TCPConn, dest []byte) (int, error) {
+	totalRead, err := conn.Read(dest)
+	if err != nil {
+		var opError *net.OpError
+		switch {
+		case errors.As(err, &opError) && opError.Timeout():
+			return totalRead, errors.New("timed out")
+		default:
+			return totalRead, err
+		}
+	}
+	return totalRead, nil
+}


### PR DESCRIPTION
# Changes
- Separated http handlers and https handlers into two different struct.
- Now we have the different serving strategies for http and https. 
- Applied the fix for malformed http request that has been mentioned in #229.
