### PR TITLE
chore: add quiet option to arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Usage: spoofdpi [options...]
   -port int
         port (default 8080)
   -silent
-        do not write anything to standart output
+        do not show the banner and server information at start up
   -system-proxy
         enable system-wide proxy (default true)
   -timeout int

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Usage: spoofdpi [options...]
         bypass DPI only on packets matching this regex pattern; can be given multiple times
   -port int
         port (default 8080)
+  -quiet
+        do not write anything to standart output
   -system-proxy
         enable system-wide proxy (default true)
   -timeout int

--- a/README.md
+++ b/README.md
@@ -18,8 +18,6 @@ See the installation guide for SpoofDPI [here](https://github.com/xvzc/SpoofDPI/
 Usage: spoofdpi [options...]
   -addr string
         listen address (default "127.0.0.1")
-  -banner
-        enable banner (default true)
   -debug
         enable debug output
   -dns-addr string

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Usage: spoofdpi [options...]
         bypass DPI only on packets matching this regex pattern; can be given multiple times
   -port int
         port (default 8080)
-  -quiet
+  -silent
         do not write anything to standart output
   -system-proxy
         enable system-wide proxy (default true)

--- a/_docs/README_ja.md
+++ b/_docs/README_ja.md
@@ -33,6 +33,8 @@ Usage: spoofdpi [options...]
         bypass DPI only on packets matching this regex pattern; can be given multiple times
   -port int
         port (default 8080)
+  -quiet
+        do not write anything to standart output
   -system-proxy
         enable system-wide proxy (default true)
   -timeout int

--- a/_docs/README_ja.md
+++ b/_docs/README_ja.md
@@ -32,7 +32,7 @@ Usage: spoofdpi [options...]
   -port int
         port (default 8080)
   -silent
-        do not write anything to standart output
+        do not show the banner and server information at start up
   -system-proxy
         enable system-wide proxy (default true)
   -timeout int

--- a/_docs/README_ja.md
+++ b/_docs/README_ja.md
@@ -33,7 +33,7 @@ Usage: spoofdpi [options...]
         bypass DPI only on packets matching this regex pattern; can be given multiple times
   -port int
         port (default 8080)
-  -quiet
+  -silent
         do not write anything to standart output
   -system-proxy
         enable system-wide proxy (default true)

--- a/_docs/README_ja.md
+++ b/_docs/README_ja.md
@@ -19,8 +19,6 @@ See the installation guide for SpoofDPI [here](https://github.com/xvzc/SpoofDPI/
 Usage: spoofdpi [options...]
   -addr string
         listen address (default "127.0.0.1")
-  -banner
-        enable banner (default true)
   -debug
         enable debug output
   -dns-addr string

--- a/_docs/README_ko.md
+++ b/_docs/README_ko.md
@@ -33,6 +33,8 @@ Usage: spoofdpi [options...]
         bypass DPI only on packets matching this regex pattern; can be given multiple times
   -port int
         port (default 8080)
+  -quiet
+        do not write anything to standart output
   -system-proxy
         enable system-wide proxy (default true)
   -timeout int

--- a/_docs/README_ko.md
+++ b/_docs/README_ko.md
@@ -32,7 +32,7 @@ Usage: spoofdpi [options...]
   -port int
         port (default 8080)
   -silent
-        do not write anything to standart output
+        do not show the banner and server information at start up
   -system-proxy
         enable system-wide proxy (default true)
   -timeout int

--- a/_docs/README_ko.md
+++ b/_docs/README_ko.md
@@ -19,8 +19,6 @@ SpoofDPI의 설치과정은 [여기](https://github.com/xvzc/SpoofDPI/blob/main/
 Usage: spoofdpi [options...]
   -addr string
         listen address (default "127.0.0.1")
-  -banner
-        enable banner (default true)
   -debug
         enable debug output
   -dns-addr string

--- a/_docs/README_ko.md
+++ b/_docs/README_ko.md
@@ -33,7 +33,7 @@ Usage: spoofdpi [options...]
         bypass DPI only on packets matching this regex pattern; can be given multiple times
   -port int
         port (default 8080)
-  -quiet
+  -silent
         do not write anything to standart output
   -system-proxy
         enable system-wide proxy (default true)

--- a/_docs/README_ru.md
+++ b/_docs/README_ru.md
@@ -18,8 +18,6 @@
 Usage: spoofdpi [опции...]
   -addr string
         listen address (default "127.0.0.1")
-  -banner
-        enable banner (default true)
   -debug
         enable debug output
   -dns-addr string

--- a/_docs/README_ru.md
+++ b/_docs/README_ru.md
@@ -31,7 +31,7 @@ Usage: spoofdpi [опции...]
   -port int
         port (default 8080)
   -silent
-        do not write anything to standart output
+        do not show the banner and server information at start up
   -system-proxy
         enable system-wide proxy (default true)
   -timeout int

--- a/_docs/README_ru.md
+++ b/_docs/README_ru.md
@@ -32,7 +32,7 @@ Usage: spoofdpi [опции...]
         bypass DPI only on packets matching this regex pattern; can be given multiple times
   -port int
         port (default 8080)
-  -quiet
+  -silent
         do not write anything to standart output
   -system-proxy
         enable system-wide proxy (default true)

--- a/_docs/README_ru.md
+++ b/_docs/README_ru.md
@@ -32,6 +32,8 @@ Usage: spoofdpi [опции...]
         bypass DPI only on packets matching this regex pattern; can be given multiple times
   -port int
         port (default 8080)
+  -quiet
+        do not write anything to standart output
   -system-proxy
         enable system-wide proxy (default true)
   -timeout int

--- a/_docs/README_zh-cn.md
+++ b/_docs/README_zh-cn.md
@@ -35,7 +35,7 @@ Usage: spoofdpi [options...]
         bypass DPI only on packets matching this regex pattern; can be given multiple times
   -port int
         port (default 8080)
-  -quiet
+  -silent
         do not write anything to standart output
   -system-proxy
         enable system-wide proxy (default true)

--- a/_docs/README_zh-cn.md
+++ b/_docs/README_zh-cn.md
@@ -34,7 +34,7 @@ Usage: spoofdpi [options...]
   -port int
         port (default 8080)
   -silent
-        do not write anything to standart output
+        do not show the banner and server information at start up
   -system-proxy
         enable system-wide proxy (default true)
   -timeout int

--- a/_docs/README_zh-cn.md
+++ b/_docs/README_zh-cn.md
@@ -21,8 +21,6 @@ See the installation guide for SpoofDPI [here](https://github.com/xvzc/SpoofDPI/
 Usage: spoofdpi [options...]
   -addr string
         listen address (default "127.0.0.1")
-  -banner
-        enable banner (default true)
   -debug
         enable debug output
   -dns-addr string

--- a/_docs/README_zh-cn.md
+++ b/_docs/README_zh-cn.md
@@ -35,6 +35,8 @@ Usage: spoofdpi [options...]
         bypass DPI only on packets matching this regex pattern; can be given multiple times
   -port int
         port (default 8080)
+  -quiet
+        do not write anything to standart output
   -system-proxy
         enable system-wide proxy (default true)
   -timeout int

--- a/cmd/spoofdpi/main.go
+++ b/cmd/spoofdpi/main.go
@@ -29,7 +29,9 @@ func main() {
 
 	pxy := proxy.New(config)
 
-	if config.Banner {
+	if config.Quiet {
+		// Print nothing
+	} else if config.Banner {
 		util.PrintColoredBanner()
 	} else {
 		util.PrintSimpleInfo()

--- a/cmd/spoofdpi/main.go
+++ b/cmd/spoofdpi/main.go
@@ -29,12 +29,8 @@ func main() {
 
 	pxy := proxy.New(config)
 
-	if config.Quiet {
-		// Print nothing
-	} else if config.Banner {
+	if !config.Silent {
 		util.PrintColoredBanner()
-	} else {
-		util.PrintSimpleInfo()
 	}
 
 	if config.SystemProxy {

--- a/util/args.go
+++ b/util/args.go
@@ -43,7 +43,7 @@ func ParseArgs() *Args {
 	uintNVar(&args.DnsPort, "dns-port", 53, "port number for dns")
 	flag.BoolVar(&args.EnableDoh, "enable-doh", false, "enable 'dns-over-https'")
 	flag.BoolVar(&args.Debug, "debug", false, "enable debug output")
-	flag.BoolVar(&args.Silent, "silent", false, "do not write anything to standart output")
+	flag.BoolVar(&args.Silent, "silent", false, "do not show the banner and server information at start up")
 	flag.BoolVar(&args.SystemProxy, "system-proxy", true, "enable system-wide proxy")
 	uintNVar(&args.Timeout, "timeout", 0, "timeout in milliseconds; no timeout when not given")
 	uintNVar(&args.WindowSize, "window-size", 0, `chunk size, in number of bytes, for fragmented client hello,

--- a/util/args.go
+++ b/util/args.go
@@ -16,7 +16,7 @@ type Args struct {
 	EnableDoh      bool
 	Debug          bool
 	Banner         bool
-	Quiet          bool
+	Silent         bool
 	SystemProxy    bool
 	Timeout        uint16
 	AllowedPattern StringArray
@@ -45,7 +45,7 @@ func ParseArgs() *Args {
 	flag.BoolVar(&args.EnableDoh, "enable-doh", false, "enable 'dns-over-https'")
 	flag.BoolVar(&args.Debug, "debug", false, "enable debug output")
 	flag.BoolVar(&args.Banner, "banner", true, "enable banner")
-	flag.BoolVar(&args.Quiet, "quiet", false, "do not write anything to standart output")
+	flag.BoolVar(&args.Silent, "silent", false, "do not write anything to standart output")
 	flag.BoolVar(&args.SystemProxy, "system-proxy", true, "enable system-wide proxy")
 	uintNVar(&args.Timeout, "timeout", 0, "timeout in milliseconds; no timeout when not given")
 	uintNVar(&args.WindowSize, "window-size", 0, `chunk size, in number of bytes, for fragmented client hello,

--- a/util/args.go
+++ b/util/args.go
@@ -15,7 +15,6 @@ type Args struct {
 	DnsPort        uint16
 	EnableDoh      bool
 	Debug          bool
-	Banner         bool
 	Silent         bool
 	SystemProxy    bool
 	Timeout        uint16
@@ -44,7 +43,6 @@ func ParseArgs() *Args {
 	uintNVar(&args.DnsPort, "dns-port", 53, "port number for dns")
 	flag.BoolVar(&args.EnableDoh, "enable-doh", false, "enable 'dns-over-https'")
 	flag.BoolVar(&args.Debug, "debug", false, "enable debug output")
-	flag.BoolVar(&args.Banner, "banner", true, "enable banner")
 	flag.BoolVar(&args.Silent, "silent", false, "do not write anything to standart output")
 	flag.BoolVar(&args.SystemProxy, "system-proxy", true, "enable system-wide proxy")
 	uintNVar(&args.Timeout, "timeout", 0, "timeout in milliseconds; no timeout when not given")

--- a/util/args.go
+++ b/util/args.go
@@ -16,6 +16,7 @@ type Args struct {
 	EnableDoh      bool
 	Debug          bool
 	Banner         bool
+	Quiet          bool
 	SystemProxy    bool
 	Timeout        uint16
 	AllowedPattern StringArray
@@ -44,6 +45,7 @@ func ParseArgs() *Args {
 	flag.BoolVar(&args.EnableDoh, "enable-doh", false, "enable 'dns-over-https'")
 	flag.BoolVar(&args.Debug, "debug", false, "enable debug output")
 	flag.BoolVar(&args.Banner, "banner", true, "enable banner")
+	flag.BoolVar(&args.Quiet, "quiet", false, "do not write anything to standart output")
 	flag.BoolVar(&args.SystemProxy, "system-proxy", true, "enable system-wide proxy")
 	uintNVar(&args.Timeout, "timeout", 0, "timeout in milliseconds; no timeout when not given")
 	uintNVar(&args.WindowSize, "window-size", 0, `chunk size, in number of bytes, for fragmented client hello,

--- a/util/config.go
+++ b/util/config.go
@@ -15,7 +15,6 @@ type Config struct {
 	DnsPort         int
 	EnableDoh       bool
 	Debug           bool
-	Banner          bool
 	Silent          bool
 	SystemProxy     bool
 	Timeout         int
@@ -39,7 +38,6 @@ func (c *Config) Load(args *Args) {
 	c.DnsPort = int(args.DnsPort)
 	c.Debug = args.Debug
 	c.EnableDoh = args.EnableDoh
-	c.Banner = args.Banner
 	c.Silent = args.Silent
 	c.SystemProxy = args.SystemProxy
 	c.Timeout = int(args.Timeout)

--- a/util/config.go
+++ b/util/config.go
@@ -69,14 +69,3 @@ func PrintColoredBanner() {
 
 	pterm.DefaultBasicText.Println("Press 'CTRL + c' to quit")
 }
-
-func PrintSimpleInfo() {
-	fmt.Println("")
-	fmt.Println("- ADDR    : ", config.Addr)
-	fmt.Println("- PORT    : ", config.Port)
-	fmt.Println("- DNS     : ", config.DnsAddr)
-	fmt.Println("- DEBUG   : ", config.Debug)
-	fmt.Println("")
-	fmt.Println("Press 'CTRL + c to quit'")
-	fmt.Println("")
-}

--- a/util/config.go
+++ b/util/config.go
@@ -16,7 +16,7 @@ type Config struct {
 	EnableDoh       bool
 	Debug           bool
 	Banner          bool
-	Quiet           bool
+	Silent          bool
 	SystemProxy     bool
 	Timeout         int
 	WindowSize      int
@@ -40,7 +40,7 @@ func (c *Config) Load(args *Args) {
 	c.Debug = args.Debug
 	c.EnableDoh = args.EnableDoh
 	c.Banner = args.Banner
-	c.Quiet = args.Quiet
+	c.Silent = args.Silent
 	c.SystemProxy = args.SystemProxy
 	c.Timeout = int(args.Timeout)
 	c.AllowedPatterns = parseAllowedPattern(args.AllowedPattern)

--- a/util/config.go
+++ b/util/config.go
@@ -16,6 +16,7 @@ type Config struct {
 	EnableDoh       bool
 	Debug           bool
 	Banner          bool
+	Quiet           bool
 	SystemProxy     bool
 	Timeout         int
 	WindowSize      int
@@ -39,6 +40,7 @@ func (c *Config) Load(args *Args) {
 	c.Debug = args.Debug
 	c.EnableDoh = args.EnableDoh
 	c.Banner = args.Banner
+	c.Quiet = args.Quiet
 	c.SystemProxy = args.SystemProxy
 	c.Timeout = int(args.Timeout)
 	c.AllowedPatterns = parseAllowedPattern(args.AllowedPattern)


### PR DESCRIPTION
I tried to write a script with SpoofDPI and found out that it doesn't have a quiet option. There is a `-banner` option that does nothing (it's true in the config by default). It is implied that the quiet option disables any output.
Moreover, in the code I found the `util.PrintSimpleInfo` function which never executes because `config.Banner` is always true. Maybe we should think about it. Personally, I like the banner by default, but it seems a little strange that we never use `util.PrintSimpleInfo`. Maybe we should delete it.