### PR TITLE
feat: add disorder support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 spoof-dpi
 spoof-dpi-*
 spoof-dpi.*
+spoofdpi
 !*/spoof-dpi/
 out/**
 

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -21,6 +21,7 @@ type Proxy struct {
 	port           int
 	timeout        int
 	resolver       *dns.Dns
+	disorder       bool
 	windowSize     int
 	enableDoh      bool
 	allowedPattern []*regexp.Regexp
@@ -35,6 +36,7 @@ func New(config *util.Config) *Proxy {
 		addr:           config.Addr,
 		port:           config.Port,
 		timeout:        config.Timeout,
+		disorder:       config.Disorder,
 		windowSize:     config.WindowSize,
 		enableDoh:      config.EnableDoh,
 		allowedPattern: config.AllowedPatterns,
@@ -109,7 +111,7 @@ func (pxy *Proxy) Start(ctx context.Context) {
 
 			var h Handler
 			if pkt.IsConnectMethod() {
-				h = handler.NewHttpsHandler(pxy.timeout, pxy.windowSize, pxy.allowedPattern, matched)
+				h = handler.NewHttpsHandler(pxy.timeout, pxy.windowSize, pxy.allowedPattern, matched, pxy.disorder)
 			} else {
 				h = handler.NewHttpHandler(pxy.timeout)
 			}

--- a/util/args.go
+++ b/util/args.go
@@ -16,6 +16,7 @@ type Args struct {
 	DnsIPv4Only    bool
 	EnableDoh      bool
 	Debug          bool
+	Disorder       bool
 	Silent         bool
 	SystemProxy    bool
 	Timeout        uint16
@@ -43,6 +44,7 @@ func ParseArgs() *Args {
 	flag.StringVar(&args.DnsAddr, "dns-addr", "8.8.8.8", "dns address")
 	uintNVar(&args.DnsPort, "dns-port", 53, "port number for dns")
 	flag.BoolVar(&args.EnableDoh, "enable-doh", false, "enable 'dns-over-https'")
+	flag.BoolVar(&args.Disorder, "disorder", false, "enable disordering Client Hello packet")
 	flag.BoolVar(&args.Debug, "debug", false, "enable debug output")
 	flag.BoolVar(&args.Silent, "silent", false, "do not show the banner and server information at start up")
 	flag.BoolVar(&args.SystemProxy, "system-proxy", true, "enable system-wide proxy")

--- a/util/config.go
+++ b/util/config.go
@@ -16,6 +16,7 @@ type Config struct {
 	DnsIPv4Only     bool
 	EnableDoh       bool
 	Debug           bool
+	Disorder        bool
 	Silent          bool
 	SystemProxy     bool
 	Timeout         int
@@ -39,6 +40,7 @@ func (c *Config) Load(args *Args) {
 	c.DnsPort = int(args.DnsPort)
 	c.DnsIPv4Only = args.DnsIPv4Only
 	c.Debug = args.Debug
+	c.Disorder = args.Disorder
 	c.EnableDoh = args.EnableDoh
 	c.Silent = args.Silent
 	c.SystemProxy = args.SystemProxy
@@ -63,10 +65,11 @@ func PrintColoredBanner() {
 	pterm.DefaultBigText.WithLetters(cyan, purple).Render()
 
 	pterm.DefaultBulletList.WithItems([]pterm.BulletListItem{
-		{Level: 0, Text: "ADDR    : " + fmt.Sprint(config.Addr)},
-		{Level: 0, Text: "PORT    : " + fmt.Sprint(config.Port)},
-		{Level: 0, Text: "DNS     : " + fmt.Sprint(config.DnsAddr)},
-		{Level: 0, Text: "DEBUG   : " + fmt.Sprint(config.Debug)},
+		{Level: 0, Text: "ADDR     : " + fmt.Sprint(config.Addr)},
+		{Level: 0, Text: "PORT     : " + fmt.Sprint(config.Port)},
+		{Level: 0, Text: "DNS      : " + fmt.Sprint(config.DnsAddr)},
+		{Level: 0, Text: "DEBUG    : " + fmt.Sprint(config.Debug)},
+		{Level: 0, Text: "DISORDER : " + fmt.Sprint(config.Disorder)},
 	}).Render()
 
 	pterm.DefaultBasicText.Println("Press 'CTRL + c' to quit")


### PR DESCRIPTION
## Add support for disordering ClientPackets

This PR introduces support for reordering `Client Hello` packets to bypass DPI mechanisms that concatenate these chunks.

 - Implements a technique to reorder packets by modifying TTL values:
   - The first packet gets TTL - 1 and is dropped by the first router.
   - The second packet gets TTL - 64 and reaches the destination.
   - The first packet eventually arrives via TCP retransmission.
 
Use the `-disorder` flag to enable this functionality.

_Note: I am not a Go dev, so there may be better approaches to implement this._