### PR TITLE
add mipsle softfloat

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -105,14 +105,25 @@ jobs:
         tar -zcvf "spoofdpi-$GOOS-$GOARCH.tar.gz" ./spoofdpi && rm -rf ./spoofdpi
         gh release upload $TAG_NAME "./spoofdpi-$GOOS-$GOARCH.tar.gz"
 
-    - name: linux/mipsle
+    - name: linux/mipsle-hardfloat
       env: 
         GOOS: linux
         GOARCH: mipsle
       run: |
         go build -ldflags="-w -s" github.com/xvzc/SpoofDPI/cmd/spoofdpi 
-        tar -zcvf "spoofdpi-$GOOS-$GOARCH.tar.gz" ./spoofdpi && rm -rf ./spoofdpi
-        gh release upload $TAG_NAME "./spoofdpi-$GOOS-$GOARCH.tar.gz"
+        tar -zcvf "spoofdpi-$GOOS-$GOARCH-hardfloat.tar.gz" ./spoofdpi && rm -rf ./spoofdpi
+        gh release upload $TAG_NAME "./spoofdpi-$GOOS-$GOARCH-hardfloat.tar.gz"
+
+    - name: linux/mipsle-softfloat
+      env: 
+        GOOS: linux
+        GOARCH: mipsle
+        GOMIPS=softfloat
+      run: |
+        go build -ldflags="-w -s" github.com/xvzc/SpoofDPI/cmd/spoofdpi 
+        tar -zcvf "spoofdpi-$GOOS-$GOARCH-softfloat.tar.gz" ./spoofdpi && rm -rf ./spoofdpi
+        gh release upload $TAG_NAME "./spoofdpi-$GOOS-$GOARCH-softfloat.tar.gz"
+
 
     - name: windows/amd64
       env: 

--- a/_docs/INSTALL.md
+++ b/_docs/INSTALL.md
@@ -32,8 +32,11 @@ curl -fsSL https://raw.githubusercontent.com/xvzc/SpoofDPI/main/install.sh | bas
 # linux-mips
 curl -fsSL https://raw.githubusercontent.com/xvzc/SpoofDPI/main/install.sh | bash -s linux-mips
 
-# linux-mipsle
-curl -fsSL https://raw.githubusercontent.com/xvzc/SpoofDPI/main/install.sh | bash -s linux-mipsle
+# linux-mipsle-hardfloat
+curl -fsSL https://raw.githubusercontent.com/xvzc/SpoofDPI/main/install.sh | bash -s linux-mipsle-hardfloat
+
+# linux-mipsle-softfloat
+curl -fsSL https://raw.githubusercontent.com/xvzc/SpoofDPI/main/install.sh | bash -s linux-mipsle-softfloat
 ```
 
 ## Go


### PR DESCRIPTION
The default mipsle binary in the release does not work on some mips devices and needs to be rebuilt with softfloat.