### PR TITLE
fix(proxy): check if hopTracker is nil before running RegisterUntracked()

### DIFF
--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -151,7 +151,7 @@ func (pxy *Proxy) handleConnection(ctx context.Context, conn net.Conn) {
 	shouldExploit := (!isPrivate && domainIncluded)
 	ctx = appctx.WithShouldExploit(ctx, shouldExploit)
 
-	if shouldExploit {
+	if pxy.hopTracker != nil && shouldExploit {
 		pxy.hopTracker.RegisterUntracked(dstAddrs)
 	}
 


### PR DESCRIPTION
This Pull Request add checking for nil hopTracker before running hopTracker.RegisterUntracked() when shouldExploit is `true`