### PR TITLE
ci: add go-test job and rename workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,6 +40,27 @@ jobs:
         env:
           CGO_ENABLED: ${{ matrix.cgo }}
 
+  go-test:
+    name: go-test on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        # run tests on ubuntu, macos, and windows
+        os: [ubuntu-latest, macos-latest]
+        go-version: ['1.24']
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ matrix.go-version }}
+
+      - name: Run tests
+        # execute tests including race condition check
+        run: go test -v -race ./...
+
   release-test:
     name: release-test
     permissions:

--- a/.github/workflows/close-inactive-issues.yaml
+++ b/.github/workflows/close-inactive-issues.yaml
@@ -1,4 +1,4 @@
-name: close-inactive-issues
+name: Close Inactive Issues
 
 on:
   schedule:

--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -1,4 +1,4 @@
-name: publish-docs
+name: Publish Docs
 
 on:
   push:


### PR DESCRIPTION
- Add `go-test` job to `ci.yaml` to run tests on Ubuntu and macOS with Go 1.24
- Rename "close-inactive-issues" workflow to "Close Inactive Issues"
- Rename "publish-docs" workflow to "Publish Docs"