### PR TITLE
fix: update help message

### DIFF
--- a/internal/config/cli.go
+++ b/internal/config/cli.go
@@ -37,8 +37,10 @@ func CreateCommand(
 		Flags: []cli.Flag{
 			&cli.BoolFlag{
 				Name: "clean",
-				Usage: `
+				Usage: fmt.Sprintf(`
 				if set, all configuration files will be ignored (default: %v)`,
+					*defaultCfg.General.Clean,
+				),
 				OnlyOnce: true,
 			},
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -125,6 +125,7 @@ func (c *Config) ShouldEnablePcap() bool {
 func getDefault() *Config { //exhaustruct:enforce
 	return &Config{
 		General: &GeneralOptions{
+			Clean:          ptr.FromValue(false),
 			LogLevel:       ptr.FromValue(zerolog.InfoLevel),
 			Silent:         ptr.FromValue(false),
 			SetSystemProxy: ptr.FromValue(false),

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -19,6 +19,7 @@ var _ merger[*GeneralOptions] = (*GeneralOptions)(nil)
 var availableLogLevels = []string{"info", "warn", "trace", "error", "debug"}
 
 type GeneralOptions struct {
+	Clean          *bool          `toml:"clean"`
 	LogLevel       *zerolog.Level `toml:"log-level"`
 	Silent         *bool          `toml:"silent"`
 	SetSystemProxy *bool          `toml:"system-proxy"`
@@ -30,6 +31,7 @@ func (o *GeneralOptions) UnmarshalTOML(data any) (err error) {
 		return fmt.Errorf("non-table type general config")
 	}
 
+	o.Clean = findFrom(m, "clean", parseBoolFn(), &err)
 	o.Silent = findFrom(m, "silent", parseBoolFn(), &err)
 	o.SetSystemProxy = findFrom(m, "system-proxy", parseBoolFn(), &err)
 	if p := findFrom(m, "log-level", parseStringFn(checkLogLevel), &err); isOk(p, err) {


### PR DESCRIPTION
This pull request fixes issues in the CLI help output related to incorrect flag defaults, options, and descriptions.

### Problems
- When rendering default values in CLI help messages, pointer-typed defaults were being printed as raw memory addresses instead of their underlying values.
- The `--dns-mode` flag options were incorrect.
- The description of the `--https-chunk-size` flag incorrectly referenced `--https-split-default` instead of `--https-split-mode`.
- The default value in the description of the `--clean` flag was not properly formatted.

### Changes
- Fixed incorrect formatting of CLI help default values by properly dereferencing pointer-based config fields, ensuring zero values such as `false` and `uint(0)` are displayed correctly instead of memory addresses.
- Corrected flag options and descriptions for improved accuracy, clarity, and consistency across the CLI help output.

### Before
<details>
<summary>Expand</summary>

```
DESCRIPTION:
  spoofdpi - Simple and fast anti-censorship tool to bypass DPI
COPYRIGHT:
  Apache License, Version 2.0, January 2004
USAGE:
  spoofdpi [global options]
GLOBAL OPTIONS:
  --clean bool 
        if set, all configuration files will be ignored (default: %v) 
  --config, -c string 
        Custom location of the config file to load. Options given through the command 
        line flags will override the options set in this file. 
  --default-ttl int 
        Default TTL value for manipulated packets. (default: 64) 
  --dns-addr string <ip:port>
        Upstream DNS server address for standard UDP queries. (default: 8.8.8.8:53) 
  --dns-cache bool 
        If set, DNS records will be cached. (default: 0x140000121b0) 
  --dns-mode string <"udp"|"doh"|"sys">
        Default resolution mode for domains that do not match any specific rule.
        (default: "udp") 
  --dns-https-url string <https_url>
        Endpoint URL for DNS over HTTPS (DoH) queries. 
        (default: "https://dns.google/dns-query") 
  --dns-qtype string <"ipv4"|"ipv6"|"all">
        Filters DNS queries by record type (A for IPv4, AAAA for IPv6).
        (default: "ipv4") 
  --https-fake-count int 
        Number of fake packets to be sent before the Client Hello.
        Requires 'https-chunk-size' > 0 for fragmentation. (default: 0x140000121b2) 
  --https-fake-packet string <byte_array>
        Comma-separated hexadecimal byte array used for fake Client Hello. 
        (default: built-in fake packet) 
  --https-disorder bool 
        If set, sends fragmented Client Hello packets out-of-order. (default: 0x140000121b1) 
  --https-split-mode string <"sni"|"random"|"chunk"|"sni"|"none">
        Specifies the default packet fragmentation strategy to use. (default: "sni") 
  --https-skip bool 
        If set, HTTPS traffic will be processed without any DPI bypass techniques. 
        (default: 0x140000121c1) 
  --https-chunk-size int 
        The chunk size (in bytes) for packet fragmentation. This value is only applied 
        when 'https-split-default' is 'chunk'. While setting the size to '0' internally 
        disables fragmentation (to avoid division-by-zero errors), you should set 
        'https-split-default' to 'none' to disable the feature cleanly.
        (default: 0x140000121c0, max: 255) 
  --listen-addr string 
        IP address to listen on (default: 127.0.0.1:8080) 
  --log-level string 
        Set log level (default: "info") 
  --policy-auto bool 
        Automatically detect the blocked sites and add policies (default: false) 
  --silent bool 
        Do not show the banner at start up (default: 0x14000012171) 
  --system-proxy bool 
        Automatically set system-wide proxy configuration (default: 0x14000012172) 
  --timeout int 
        Timeout for tcp connection in milliseconds. 
        No effect when the value is 0 (default: 0s, max: 65535) 
  --version, -v bool 
        Print version; this may contain some other relevant information 
  --help, -h bool 
        show help
```

</details>

### After
<details>
<summary>Expand</summary>

```
DESCRIPTION:
  spoofdpi - Simple and fast anti-censorship tool to bypass DPI
COPYRIGHT:
  Apache License, Version 2.0, January 2004
USAGE:
  spoofdpi [global options]
GLOBAL OPTIONS:
  --clean bool 
        if set, all configuration files will be ignored (default: false) 
  --config, -c string 
        Custom location of the config file to load. Options given through the command 
        line flags will override the options set in this file. 
  --default-ttl int 
        Default TTL value for manipulated packets. (default: 64) 
  --dns-addr string <ip:port>
        Upstream DNS server address for standard UDP queries. (default: 8.8.8.8:53) 
  --dns-cache bool 
        If set, DNS records will be cached. (default: false) 
  --dns-mode string <"udp"|"https"|"system">
        Default resolution mode for domains that do not match any specific rule.
        (default: "udp") 
  --dns-https-url string <https_url>
        Endpoint URL for DNS over HTTPS (DoH) queries. 
        (default: "https://dns.google/dns-query") 
  --dns-qtype string <"ipv4"|"ipv6"|"all">
        Filters DNS queries by record type (A for IPv4, AAAA for IPv6).
        (default: "ipv4") 
  --https-fake-count int 
        Number of fake packets to be sent before the Client Hello.
        Requires 'https-chunk-size' > 0 for fragmentation. (default: 0) 
  --https-fake-packet string <byte_array>
        Comma-separated hexadecimal byte array used for fake Client Hello. 
        (default: built-in fake packet) 
  --https-disorder bool 
        If set, sends fragmented Client Hello packets out-of-order. (default: false) 
  --https-split-mode string <"sni"|"random"|"chunk"|"sni"|"none">
        Specifies the default packet fragmentation strategy to use. (default: "sni") 
  --https-skip bool 
        If set, HTTPS traffic will be processed without any DPI bypass techniques. 
        (default: false) 
  --https-chunk-size int 
        The chunk size (in bytes) for packet fragmentation. This value is only applied 
        when 'https-split-mode' is 'chunk'. While setting the size to '0' internally 
        disables fragmentation (to avoid division-by-zero errors), you should set 
        'https-split-mode' to 'none' to disable the feature cleanly.
        (default: 0, max: 255) 
  --listen-addr string 
        IP address to listen on (default: 127.0.0.1:8080) 
  --log-level string 
        Set log level (default: "info") 
  --policy-auto bool 
        Automatically detect the blocked sites and add policies (default: false) 
  --silent bool 
        Do not show the banner at start up (default: false) 
  --system-proxy bool 
        Automatically set system-wide proxy configuration (default: false) 
  --timeout int 
        Timeout for tcp connection in milliseconds. 
        No effect when the value is 0 (default: 0s, max: 65535) 
  --version, -v bool 
        Print version; this may contain some other relevant information 
  --help, -h bool 
        show help
```

</details>