### PR TITLE
fix(main): return early when createServer fails to avoid nil-deref on ListenAndServe

### DIFF
--- a/cmd/spoofdpi/main.go
+++ b/cmd/spoofdpi/main.go
@@ -124,6 +124,7 @@ func runApp(mainctx context.Context, configDir string, cfg *config.Config) error
 	srv, err := createServer(appctx, logger, cfg, resolver)
 	if err != nil {
 		logger.Error().Err(err).Msg("failed to create server")
+		return err
 	}
 
 	logger.Info().Msg("dns info")


### PR DESCRIPTION
Fixes #381.

`runApp` logged `createServer` errors but continued, then called `srv.ListenAndServe` on a nil receiver. The user's repro path ("start spoofdpi without Wi-Fi connected" — no default route, network detector startup fails inside `createServer`) hit it directly. Return the error instead so the CLI exits cleanly with the wrapped `failed to create server` log line.