### PR TITLE
fix: allow proxy startup without an active default route

### DIFF
--- a/cmd/spoofdpi/main.go
+++ b/cmd/spoofdpi/main.go
@@ -33,6 +33,8 @@ var (
 	build   = "unknown"
 )
 
+var defaultRouteFunc = netutil.DefaultRoute
+
 type SwitchableWriter struct {
 	// target is a pointer to an interface, or just the interface itself.
 	// We use a pointer to the interface for direct updates.
@@ -124,6 +126,7 @@ func runApp(mainctx context.Context, configDir string, cfg *config.Config) error
 	srv, err := createServer(appctx, logger, cfg, resolver)
 	if err != nil {
 		logger.Error().Err(err).Msg("failed to create server")
+		return err
 	}
 
 	logger.Info().Msg("dns info")
@@ -360,13 +363,20 @@ func createServer(
 		tcpSniffer,
 	)
 
-	defaultRoute, err := netutil.DefaultRoute()
-	if err != nil {
-		return nil, fmt.Errorf("failed to find default route: %w", err)
-	}
-
 	switch *cfg.App.Mode {
 	case config.AppModeHTTP:
+		var sysNet http.HTTPSystemNetwork
+		if cfg.App.AutoConfigureNetwork != nil && *cfg.App.AutoConfigureNetwork {
+			route, err := defaultRouteFunc()
+			if err != nil {
+				return nil, fmt.Errorf("failed to find default route: %w", err)
+			}
+			sysNet = http.NewHTTPSystemNetwork(
+				logging.WithScope(logger, "sys"),
+				route,
+			)
+		}
+
 		httpHandler := http.NewHTTPHandler(logging.WithScope(logger, "hnd"))
 		httpsHandler := http.NewHTTPSHandler(
 			logging.WithScope(logger, "hnd"),
@@ -374,11 +384,6 @@ func createServer(
 			tcpSniffer,
 			cfg.HTTPS.Clone(),
 			cfg.Conn.Clone(),
-		)
-
-		sysNet := http.NewHTTPSystemNetwork(
-			logging.WithScope(logger, "sys"),
-			defaultRoute,
 		)
 
 		return http.NewHTTPProxy(
@@ -393,6 +398,18 @@ func createServer(
 			cfg.Policy.Clone(),
 		), nil
 	case config.AppModeSOCKS5:
+		var sysNet socks5.SOCKS5SystemNetwork
+		if cfg.App.AutoConfigureNetwork != nil && *cfg.App.AutoConfigureNetwork {
+			route, err := defaultRouteFunc()
+			if err != nil {
+				return nil, fmt.Errorf("failed to find default route: %w", err)
+			}
+			sysNet = socks5.NewSOCKS5SystemNetwork(
+				logging.WithScope(logger, "sys"),
+				route,
+			)
+		}
+
 		connectHandler := socks5.NewConnectHandler(
 			logging.WithScope(logger, "hnd"),
 			desyncer,
@@ -423,15 +440,13 @@ func createServer(
 			connectHandler,
 			bindHandler,
 			udpAssociateHandler,
-			socks5.NewSOCKS5SystemNetwork(
-				logging.WithScope(logger, "sys"),
-				defaultRoute,
-			),
+			sysNet,
 			cfg.App.Clone(),
 			cfg.Conn.Clone(),
 			cfg.Policy.Clone(),
 		), nil
 	case config.AppModeTUN:
+		defaultRoute, err := defaultRouteFunc()
 		if err != nil {
 			return nil, fmt.Errorf("failed to get default route: %w", err)
 		}

--- a/cmd/spoofdpi/main_test.go
+++ b/cmd/spoofdpi/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"net"
 	"testing"
 	"time"
@@ -11,6 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/xvzc/spoofdpi/internal/config"
+	"github.com/xvzc/spoofdpi/internal/netutil"
 	"github.com/xvzc/spoofdpi/internal/proto"
 )
 
@@ -138,4 +140,79 @@ func TestCreateProxy_WithPolicy(t *testing.T) {
 	p, err := createServer(context.Background(), logger, cfg, resolver)
 	require.NoError(t, err)
 	assert.NotNil(t, p)
+}
+
+func TestCreateServer_HTTPDoesNotRequireDefaultRouteWithoutAutoConfigure(t *testing.T) {
+	cfg := testServerConfig(config.AppModeHTTP, false)
+
+	calls := 0
+	origDefaultRouteFunc := defaultRouteFunc
+	defaultRouteFunc = func() (*netutil.Route, error) {
+		calls++
+		return nil, errors.New("network is unavailable")
+	}
+	t.Cleanup(func() { defaultRouteFunc = origDefaultRouteFunc })
+
+	logger := zerolog.Nop()
+	resolver := createResolver(logger, cfg)
+
+	p, err := createServer(context.Background(), logger, cfg, resolver)
+	require.NoError(t, err)
+	assert.NotNil(t, p)
+	assert.Equal(t, 0, calls)
+}
+
+func TestCreateServer_HTTPRequiresDefaultRouteWithAutoConfigure(t *testing.T) {
+	cfg := testServerConfig(config.AppModeHTTP, true)
+
+	origDefaultRouteFunc := defaultRouteFunc
+	defaultRouteFunc = func() (*netutil.Route, error) {
+		return nil, errors.New("network is unavailable")
+	}
+	t.Cleanup(func() { defaultRouteFunc = origDefaultRouteFunc })
+
+	logger := zerolog.Nop()
+	resolver := createResolver(logger, cfg)
+
+	p, err := createServer(context.Background(), logger, cfg, resolver)
+	require.Error(t, err)
+	assert.Nil(t, p)
+	assert.ErrorContains(t, err, "failed to find default route")
+}
+
+func testServerConfig(mode config.AppModeType, autoConfigureNetwork bool) *config.Config {
+	cfg := config.NewConfig()
+
+	cfg.App = &config.AppOptions{
+		Mode:                 lo.ToPtr(mode),
+		AutoConfigureNetwork: lo.ToPtr(autoConfigureNetwork),
+		ListenAddr:           &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 0},
+	}
+	cfg.Conn = &config.ConnOptions{
+		DefaultFakeTTL: lo.ToPtr(uint8(64)),
+		DNSTimeout:     lo.ToPtr(time.Duration(0)),
+		TCPTimeout:     lo.ToPtr(time.Duration(0)),
+		UDPIdleTimeout: lo.ToPtr(time.Duration(0)),
+	}
+	cfg.HTTPS = &config.HTTPSOptions{
+		Disorder:   lo.ToPtr(false),
+		FakeCount:  lo.ToPtr(uint8(0)),
+		FakePacket: proto.NewFakeTLSMessage([]byte{}),
+		SplitMode:  lo.ToPtr(config.HTTPSSplitModeChunk),
+		ChunkSize:  lo.ToPtr(uint8(10)),
+		Skip:       lo.ToPtr(false),
+	}
+	cfg.UDP = &config.UDPOptions{
+		FakeCount: lo.ToPtr(0),
+	}
+	cfg.Policy = &config.PolicyOptions{}
+	cfg.DNS = &config.DNSOptions{
+		Mode:     lo.ToPtr(config.DNSModeUDP),
+		Addr:     &net.TCPAddr{IP: net.ParseIP("8.8.8.8"), Port: 53},
+		HTTPSURL: lo.ToPtr("https://dns.google/dns-query"),
+		QType:    lo.ToPtr(config.DNSQueryIPv4),
+		Cache:    lo.ToPtr(false),
+	}
+
+	return cfg
 }


### PR DESCRIPTION
Fixes https://github.com/xvzc/spoofdpi/issues/381.

Fixed startup behavior when no network/default route is available.

- HTTP/SOCKS5 proxy startup no longer requires an active default route unless auto-configure-network is enabled.
- TUN mode still requires a default route as before.
- Server creation errors now stop startup cleanly instead of leading to a nil server panic.
- Added tests covering startup without a default route.