### PR TITLE
build(nix): derive flake version from manifest

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1762363567,
-        "narHash": "sha256-YRqMDEtSMbitIMj+JLpheSz0pwEr0Rmy5mC7myl17xs=",
+        "lastModified": 1777578337,
+        "narHash": "sha256-Ad49moKWeXtKBJNy2ebiTQUEgdLyvGmTeykAQ9xM+Z4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ae814fd3904b621d8ab97418f1d0f2eb0d3716f4",
+        "rev": "15f4ee454b1dce334612fa6843b3e05cf546efab",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -16,19 +16,23 @@
       system:
       let
         pkgs = nixpkgs.legacyPackages.${system};
+        manifest = builtins.fromJSON (builtins.readFile ./.manifest.json);
+        version = manifest.".";
+        go = pkgs.go_1_26;
       in
       {
         packages.default = pkgs.buildGoModule {
+          inherit version go;
           pname = "spoofdpi";
-          version = "dev";
           src = self;
-          vendorHash = "sha256-FcepbOIB3CvHmTPiGWXukPg41uueQQYdZeVKmzjRuwA=";
+          vendorHash = "sha256-KHP6497t4DFnYyTkcuTaCrpK6j14AwWjZeYDyEfjXBg=";
           subPackages = [ "cmd/spoofdpi" ];
           buildInputs = pkgs.lib.optionals pkgs.stdenv.isDarwin [ pkgs.libpcap ];
-          env.CGO_ENABLED = if pkgs.stdenv.isLinux then "0" else "1";
+          env.CGO_ENABLED = if pkgs.stdenv.isDarwin then "1" else "0";
           ldflags = [
             "-s"
             "-w"
+            "-X main.version=${version}"
             "-X main.build=flake"
             "-X main.commit=${self.shortRev or "dirty"}"
           ];
@@ -38,6 +42,8 @@
             license = pkgs.lib.licenses.asl20;
           };
         };
+
+        devShells.default = import ./shell.nix { inherit pkgs; };
       }
     );
 }


### PR DESCRIPTION
<details><summary>Original Content</summary>

## Summary

This PR focuses on making the Nix flake sustainable.

## Changes

- Added `VERSION` as the source of truth for builds.
- Updated the flake to read the package version from `VERSION`.
- Updated GoReleaser workflows to pass `VERSION` explicitly.
- Separated network-dependent tests behind the `network` build tag.

## Notes

This changes part of the release workflow.

Previously, the build version was derived from the Git tag. Since Nix builds need a version available from the source tree, this PR introduces the `VERSION` file instead. The existing release pipeline may need to be adjusted accordingly.

## Example Workflow

```
❯ nix develop --command -- task build
task: [build] go build ./cmd/...
❯ ./spoofdpi --version
spoofdpi dev unknown (unknown)
Official docs at https://spoofdpi.xvzc.dev
```

```
❯ nix build
❯ result/bin/spoofdpi --version
spoofdpi 1.4.1 6068782 (flake)
Official docs at https://spoofdpi.xvzc.dev
```

```
❯ nix run . -- --version
spoofdpi 1.4.1 6068782 (flake)
Official docs at https://spoofdpi.xvzc.dev
```

</details>

**UPDATE**:

## Summary

Updates the Nix flake to derive the package version from `.manifest.json` instead of using a hardcoded `dev` value.

## Changes

- Reads the release manifest in `flake.nix`
- Uses the manifest version for the Nix package version
- Passes the same version into `main.version` via ldflags
- Updates `flake.lock` and `vendorHash` for the flake build
