### PR TITLE
test: run network-dependent tests with network tag

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -1,6 +1,6 @@
 # Testing
 
-After any code change, run `go test ./...` from the project root and all tests must pass before considering the task complete.
+After any code change, run `go test -tags network ./...` from the project root and all tests must pass before considering the task complete. Use `go test ./...` only when network-dependent tests must be excluded, such as sandboxed Nix builds.
 
 These conventions follow the patterns established in `internal/config/*_test.go`. Apply them to new tests; only deviate when there is a clear, code-specific reason.
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Run tests
         # execute tests including race condition check
-        run: go test -v -race ./...
+        run: go test -v -race -tags network ./...
 
   release-test:
     name: release-test

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -16,7 +16,7 @@ tasks:
 
   test:
     desc: Run tests with race detector
-    cmd: go test {{.CLI_ARGS}} -race ./...
+    cmd: go test {{.CLI_ARGS}} -race -tags network ./...
 
   lint:
     desc: Run golangci-lint

--- a/cmd/spoofdpi/main_test.go
+++ b/cmd/spoofdpi/main_test.go
@@ -1,3 +1,5 @@
+//go:build network
+
 package main
 
 import (

--- a/docs/developer-guide/testing.md
+++ b/docs/developer-guide/testing.md
@@ -4,16 +4,22 @@ This document outlines how to run tests and the conventions for writing new test
 
 ## Running Tests
 
-To run all tests in the project, use the standard `go test` command from the root directory:
+To run tests that do not require network access, use the standard `go test` command from the root directory:
 
 ```console
 $ go test ./...
 ```
 
-To run tests with verbose output (showing all test names):
+To run all tests, including tests that require network access, pass the `network` build tag:
 
 ```console
-$ go test -v ./...
+$ go test -tags network ./...
+```
+
+To run all tests with verbose output (showing all test names):
+
+```console
+$ go test -v -tags network ./...
 ```
 
 To run a specific test function (e.g., `TestCreateCommand_Flags`):


### PR DESCRIPTION
## Summary

- Introduce the `network` build tag for tests that require network access
- Exclude network-dependent tests from the default `go test ./...` path
- Update CI, Taskfile, and testing docs to run full tests with `-tags network`

## Context

Nix builds run in a sandboxed environment where network access is unavailable. Marking network-dependent tests behind an explicit build tag allows the default test suite to pass during `nix build`, while still preserving a clear path for running the full test suite locally and in CI.
