### PR TITLE
fix(release): drop bogus mips64 hardfloat suffix from archive names

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -63,8 +63,6 @@ archives:
       {{- .Os }}_
       {{- if eq .Arch "386" }}i386
       {{- else if eq .Arch "amd64" }}x86_64
-      {{- else if eq .Arch "mips64" }}mips64_hardfloat
-      {{- else if eq .Arch "mips64le" }}mips64le_hardfloat
       {{- else }}{{ .Arch }}{{ end -}}
     formats: ['tar.gz']
     # Explicitly list builds to include (optional but good for clarity)


### PR DESCRIPTION
## Summary

- Archive name template hardcoded `mips64_hardfloat` / `mips64le_hardfloat` suffixes even though `gomips` is set to `softfloat`, so files named `*_hardfloat.tar.gz` actually contain softfloat builds.
- Drop the suffix entirely and let the default `{{ .Arch }}` branch produce `mips64` / `mips64le`. The name now matches the real build.

## Test plan

- [ ] CI release-test (goreleaser snapshot) succeeds
- [ ] CI nix-build job succeeds on linux + macos