### PR TITLE
ci(release): skip release workflow on forks

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,7 +21,7 @@ env:
 
 jobs:
   release-please:
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' && !github.event.repository.fork
     name: release-please
     runs-on: ubuntu-latest
     outputs:
@@ -37,7 +37,7 @@ jobs:
   build-and-publish:
     needs: release-please
     if: |
-      !cancelled() && (
+      !github.event.repository.fork && !cancelled() && (
         (github.event_name == 'push' && needs.release-please.outputs.release_created == 'true') ||
         github.event_name == 'workflow_dispatch'
       )


### PR DESCRIPTION
## Summary

- Without a guard, forks that push to their main branch silently trigger the release workflow on their own repo: release-please opens unwanted release PRs and goreleaser tries to build/publish artifacts the fork owner never asked for.
- Gate both jobs on \`!github.event.repository.fork\` so forks see the workflow as "skipped" instead of executing.

## Test plan

- [ ] CI lint passes
- [ ] (manual) Verify on the fork side that pushing to main shows the jobs as skipped, not failing