### PR TITLE
chore(tui): use ansi green for logo

### DIFF
--- a/cmd/spoofdpi/tui.go
+++ b/cmd/spoofdpi/tui.go
@@ -19,8 +19,8 @@ import (
 var (
 	logoStyle = lipgloss.NewStyle().
 			Foreground(lipgloss.Color("2")).
-			Bold(true).
-			MarginBottom(0)
+		// Bold(false).
+		MarginBottom(0)
 
 	speedStyle = lipgloss.NewStyle().
 			Foreground(lipgloss.Color("255")).
@@ -86,7 +86,7 @@ func initialModel(readyChan chan struct{}) model {
 		FPS:    time.Second / 25,
 	}
 
-	s.Style = lipgloss.NewStyle().Foreground(lipgloss.Color("119"))
+	s.Style = lipgloss.NewStyle().Foreground(lipgloss.Color("255"))
 
 	return model{
 		spinner:      s,

--- a/cmd/spoofdpi/tui.go
+++ b/cmd/spoofdpi/tui.go
@@ -18,7 +18,7 @@ import (
 // UI styling
 var (
 	logoStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("#00ff00")).
+			Foreground(lipgloss.Color("2")).
 			Bold(true).
 			MarginBottom(0)
 


### PR DESCRIPTION
## Summary

Use the standard ANSI green for the TUI logo instead of a hard-coded truecolor RGB value.

This lets the logo follow the user’s terminal color scheme more naturally, assuming the exact `#00ff00` shade was not intentionally chosen as part of the design.

This is mostly a preference-driven tweak and is not something I think must be applied. Please feel free to push back or suggest a different direction. :)

<img width="1643" height="747" alt="image" src="https://github.com/user-attachments/assets/bd7e254e-b4b8-41d9-b56f-7f90c7ae5de6" />
