### PR TITLE
feat(config): rename match key domain to domains

### DIFF
--- a/docs/user-guide/examples.md
+++ b/docs/user-guide/examples.md
@@ -33,18 +33,18 @@ Route traffic differently based on the domain or IP address.
 # Block ads
 [[rules]]
     name = "block ads"
-    match = { domain = ["ads.example.com"] }
+    match = { domains = ["ads.example.com"] }
     block = true
 
 # Bypass DPI for specific blocked site
 [[rules]]
     name = "unblock site"
-    match = { domain = ["blocked-site.com"] }
-    https = { fake-count = 7, disorder = true }
+    match = { domains = ["blocked-site.com"] }
+    https = { fake-count = 2, disorder = true }
 
 # Use local network directly (no processing)
 [[rules]]
     name = "local bypass"
-    match = { addr = [{ cidr = "192.168.0.0/16", port = "all" }] }
+    match = { cidrs = ["192.168.0.0/16"] }
     https = { skip = true }
 ```

--- a/docs/user-guide/examples.md
+++ b/docs/user-guide/examples.md
@@ -8,8 +8,8 @@ A minimal configuration to get started with DNS over HTTPS (DoH) and basic DPI b
 
 ```toml
 [dns]
-    mode = "https"
-    https-url = "https://dns.google/dns-query"
+mode = "https"
+https-url = "https://dns.google/dns-query"
 ```
 
 ## Aggressive Bypass
@@ -18,11 +18,11 @@ If the default settings are not enough, you can try more aggressive settings. Th
 
 ```toml
 [https]
-    fake-count = 5
-    fake-packet = [0x16, 0x03, 0x01] # Simple fake Client Hello prefix
-    disorder = true
-    split-mode = "chunk"
-    chunk-size = 1
+fake-count = 5
+fake-packet = [0x16, 0x03, 0x01] # Simple fake Client Hello prefix
+disorder = true
+split-mode = "chunk"
+chunk-size = 1
 ```
 
 ## Rule-Based Routing
@@ -32,19 +32,19 @@ Route traffic differently based on the domain or IP address.
 ```toml
 # Block ads
 [[rules]]
-    name = "block ads"
-    match = { domains = ["ads.example.com"] }
-    block = true
+name = "block ads"
+match = { domains = ["ads.example.com"] }
+block = true
 
 # Bypass DPI for specific blocked site
 [[rules]]
-    name = "unblock site"
-    match = { domains = ["blocked-site.com"] }
-    https = { fake-count = 2, disorder = true }
+name = "unblock site"
+match = { domains = ["blocked-site.com"] }
+https = { fake-count = 2, disorder = true }
 
 # Use local network directly (no processing)
 [[rules]]
-    name = "local bypass"
-    match = { cidrs = ["192.168.0.0/16"] }
-    https = { skip = true }
+name = "local bypass"
+match = { cidrs = ["192.168.0.0/16"] }
+https = { skip = true }
 ```

--- a/docs/user-guide/rules.md
+++ b/docs/user-guide/rules.md
@@ -19,28 +19,21 @@ The top-level `[[rules]]` array contains one table per rule. Each rule consists 
 
 ## Match Criteria (`match`)
 
-You can specify a `domain` list or an `addr` list (containing `cidr` and `port`).
+You can specify a `domains` list or a `cidrs` list.
 
-| Field    | Type   | Description                                                                 |
-| :------- | :----- | :-------------------------------------------------------------------------- |
-| `domain` | Array  | List of domain patterns. Supports wildcards (`*`, `**`).                    |
-| `addr`   | Array  | List of address rules. Each rule requires `cidr` and `port`.                |
-
-### Address Rule (`addr`)
-
-| Field  | Type   | Description                                                                 |
-| :----- | :----- | :-------------------------------------------------------------------------- |
-| `cidr` | String | IP range in CIDR notation (e.g., `192.168.0.0/24`).                         |
-| `port` | String | Port or port range (e.g., `80`, `80-443`, `all`).                          |
+| Field     | Type   | Description                                                                 |
+| :-------- | :----- | :-------------------------------------------------------------------------- |
+| `domains` | Array  | List of domain patterns. Supports wildcards (`*`, `**`).                    |
+| `cidrs`   | Array  | List of IP ranges in CIDR notation (e.g., `["10.0.0.0/8"]`).               |
 
 ### File-based match lists
 
-Both `domain` and `cidrs` accept items with a `file:` prefix. The path after the prefix is read line by line, and each non-empty, non-comment line is treated as an additional item.
+Both `domains` and `cidrs` accept items with a `file:` prefix. The path after the prefix is read line by line, and each non-empty, non-comment line is treated as an additional item.
 
 ```toml
 [[rules]]
     name = "streaming"
-    match = { domain = ["file:assets/streaming-domains.txt", "*.youtube.com"] }
+    match = { domains = ["file:assets/streaming-domains.txt", "*.youtube.com"] }
     https = { fake-count = 5 }
 ```
 
@@ -99,21 +92,21 @@ Customize how HTTPS connections are established. The available fields mirror the
 [[rules]]
     name = "allow youtube"
     priority = 50
-    match = { domain = ["*.youtube.com"] }
+    match = { domains = ["*.youtube.com"] }
     https = { disorder = true, fake-count = 7 }
 
 # Example B: Bypass DPI for local network traffic (Standard Connection)
 [[rules]]
     name = "skip local"
     priority = 51
-    match = { addr = [{ cidr = "192.168.0.0/24", port = "all" }] }
+    match = { cidrs = ["192.168.0.0/24"] }
     https = { skip = true }
 
 # Example C: Block a specific domain
 [[rules]]
     name = "block ads"
     priority = 100
-    match = { domain = ["ads.example.com"] }
+    match = { domains = ["ads.example.com"] }
     block = true
 ```
 
@@ -125,6 +118,6 @@ Earlier versions used `[[policy.overrides]]` instead of `[[rules]]`. The old key
 # Deprecated form — still works, prints a warning
 [[policy.overrides]]
     name = "allow youtube"
-    match = { domain = ["*.youtube.com"] }
+    match = { domains = ["*.youtube.com"] }
     https = { fake-count = 7 }
 ```

--- a/docs/user-guide/rules.md
+++ b/docs/user-guide/rules.md
@@ -32,9 +32,9 @@ Both `domains` and `cidrs` accept items with a `file:` prefix. The path after th
 
 ```toml
 [[rules]]
-    name = "streaming"
-    match = { domains = ["file:assets/streaming-domains.txt", "*.youtube.com"] }
-    https = { fake-count = 5 }
+name = "streaming"
+match = { domains = ["file:assets/streaming-domains.txt", "*.youtube.com"] }
+https = { fake-count = 5 }
 ```
 
 **Path resolution**
@@ -90,24 +90,24 @@ Customize how HTTPS connections are established. The available fields mirror the
 ```toml
 # Example A: Allow YouTube with specific DPI bypass settings
 [[rules]]
-    name = "allow youtube"
-    priority = 50
-    match = { domains = ["*.youtube.com"] }
-    https = { disorder = true, fake-count = 7 }
+name = "allow youtube"
+priority = 50
+match = { domains = ["*.youtube.com"] }
+https = { disorder = true, fake-count = 7 }
 
 # Example B: Bypass DPI for local network traffic (Standard Connection)
 [[rules]]
-    name = "skip local"
-    priority = 51
-    match = { cidrs = ["192.168.0.0/24"] }
-    https = { skip = true }
+name = "skip local"
+priority = 51
+match = { cidrs = ["192.168.0.0/24"] }
+https = { skip = true }
 
 # Example C: Block a specific domain
 [[rules]]
-    name = "block ads"
-    priority = 100
-    match = { domains = ["ads.example.com"] }
-    block = true
+name = "block ads"
+priority = 100
+match = { domains = ["ads.example.com"] }
+block = true
 ```
 
 ## Deprecated: `[[policy.overrides]]`
@@ -117,7 +117,7 @@ Earlier versions used `[[policy.overrides]]` instead of `[[rules]]`. The old key
 ```toml
 # Deprecated form — still works, prints a warning
 [[policy.overrides]]
-    name = "allow youtube"
-    match = { domains = ["*.youtube.com"] }
-    https = { fake-count = 7 }
+name = "allow youtube"
+match = { domains = ["*.youtube.com"] }
+https = { fake-count = 7 }
 ```

--- a/internal/config/cli_test.go
+++ b/internal/config/cli_test.go
@@ -211,10 +211,8 @@ func TestCreateCommand_OverrideTOML(t *testing.T) {
     priority = 100
     block = true
     match = {
-        domain = ["example.com"],
-        addr = [
-            {cidr = "192.168.1.0/24", port = "80-443"}
-        ]
+        domains = ["example.com"],
+        cidrs = ["192.168.1.0/24"],
     }
     dns = {
         mode = "udp",
@@ -331,7 +329,7 @@ func TestLoad_RuleInheritsFromCLIAndTOML(t *testing.T) {
 
 [[rules]]
     name = "partial-rule"
-    match = { domain = ["example.com"] }
+    match = { domains = ["example.com"] }
     https = { chunk-size = 50, skip = true }
 `
 	tmpDir := t.TempDir()

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -28,7 +28,7 @@ func TestConfig_UnmarshalTOML(t *testing.T) {
 						{
 							"name": "test",
 							"match": map[string]any{
-								"domain": []any{"example.com"},
+								"domains": []any{"example.com"},
 							},
 							"dns": map[string]any{
 								"route": "doh",
@@ -219,7 +219,7 @@ func TestResolveRules_inheritsFromBase(t *testing.T) {
 		{
 			"name": "rule1",
 			"match": map[string]any{
-				"domain": []any{"example.com"},
+				"domains": []any{"example.com"},
 			},
 			"https": map[string]any{
 				// Only override fake-count; other HTTPS fields should
@@ -305,7 +305,7 @@ func TestResolveRules_skipNotInheritedFromBase(t *testing.T) {
 
 			item := map[string]any{
 				"name":  "r",
-				"match": map[string]any{"domain": []any{"example.com"}},
+				"match": map[string]any{"domains": []any{"example.com"}},
 			}
 			if tc.ruleHTTPS != nil {
 				item["https"] = tc.ruleHTTPS

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -182,7 +182,7 @@ func resolveRules(raw []map[string]any, base RuntimeConfig) ([]Rule, error) {
 	return rules, nil
 }
 
-// expandFileMatchList expands any file: entries in the domain/cidrs
+// expandFileMatchList expands any file: entries in the domains/cidrs
 // arrays of a raw match map in-place. Missing files emit a warning via
 // AddWarnMsg; other I/O failures return an error.
 func expandFileMatchList(v any, ruleIdx int, configDir string) error {
@@ -190,7 +190,7 @@ func expandFileMatchList(v any, ruleIdx int, configDir string) error {
 	if !ok {
 		return nil
 	}
-	for _, key := range []string{"domain", "cidrs"} {
+	for _, key := range []string{"domains", "cidrs"} {
 		arr, ok := m[key].([]any)
 		if !ok {
 			continue

--- a/internal/config/toml_test.go
+++ b/internal/config/toml_test.go
@@ -446,7 +446,7 @@ func TestFromTomlFile(t *testing.T) {
 				priority = 100
 				block = true
 				match = {
-					domain = ["example.com"],
+					domains = ["example.com"],
 					cidrs = ["192.168.1.0/24"]
 				}
 				dns = {

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -576,7 +576,7 @@ func (o *UDPOptions) UnmarshalTOML(data any) (err error) {
 // └──────────────┘
 
 type MatchAttrs struct {
-	Domains []string `toml:"domain"`
+	Domains []string `toml:"domains"`
 	CIDRs   []string `toml:"cidrs"`
 }
 
@@ -600,7 +600,7 @@ func (a *MatchAttrs) UnmarshalTOML(data any) (err error) {
 		return fmt.Errorf("'match' must be table type")
 	}
 
-	if raw := findSliceFrom(v, "domain", parseStringFn(nil), &err); raw != nil {
+	if raw := findSliceFrom(v, "domains", parseStringFn(nil), &err); raw != nil {
 		for _, d := range raw {
 			if e := checkDomainPattern(d); e != nil {
 				return fmt.Errorf("invalid domain %q: %w", d, e)

--- a/internal/config/types_test.go
+++ b/internal/config/types_test.go
@@ -227,7 +227,7 @@ func TestMatchAttrs_UnmarshalTOML(t *testing.T) {
 		{
 			name: "valid domain",
 			input: map[string]any{
-				"domain": []any{"example.com"},
+				"domains": []any{"example.com"},
 			},
 			wantErr: false,
 			assert: func(t *testing.T, m MatchAttrs) {
@@ -294,7 +294,7 @@ func TestRule_UnmarshalTOML(t *testing.T) {
 			input: map[string]any{
 				"name": "rule1",
 				"match": map[string]any{
-					"domain": []any{"example.com"},
+					"domains": []any{"example.com"},
 				},
 				"block": true,
 			},

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -143,7 +143,7 @@ func checkRule(r Rule) error {
 
 func checkMatchAttrs(m MatchAttrs) error {
 	if len(m.Domains) == 0 && len(m.CIDRs) == 0 {
-		return fmt.Errorf("match must have at least one 'domain' or 'cidrs' entry")
+		return fmt.Errorf("match must have at least one 'domains' or 'cidrs' entry")
 	}
 	return nil
 }


### PR DESCRIPTION
Rename `match.domain` to `match.domains`. Fix stale `addr/{cidr,port}` docs and remove non-standard TOML indentation.